### PR TITLE
Fix two bugs in trace_hb_check_2

### DIFF
--- a/test/trace_hb_check_2.cpp
+++ b/test/trace_hb_check_2.cpp
@@ -64,9 +64,11 @@ check_conforming(const void *entry, metadata_t *md)
             // do not check after one thread can have finished the atomics
             return;
         }
-        if (fetch_add_return_values[count] == 0) {
-            // it can happen that this is not yet written, because that write is
-            // instrumented and triggers the creation of a new file
+        if (count > 0 && fetch_add_return_values[count] == 0) {
+            // it can happen that the return value was not yet written, because
+            // that write is instrumented and triggers the creation of a new
+            // file
+            count++;
             return;
         }
         // check that the r/w operations for return value x have idx 2x/ 2x + 1


### PR DESCRIPTION
One bug occurs when a return value of a fetch_add has not yet been stored, because the tsan_write operation led to the creation of a new file and thus a call to the checker for the old file. The check of the return value was already skipped in that case, but the counter was not incremented, leading to comparing the wrong return values.

The second bug was that checking was skipped for one thread, because the return value of the first fetch_add is 0. Since the count idx was not advanced, it was still 0 on the next check, leading to not checking at any time.