### PR TITLE
chore: enable dice-memset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ endif()
 
 add_compile_options(-fPIC -g3 -D_GNU_SOURCE -DDICE_MAIN_START_DISABLE)
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+set(DICE_MEMSET ON)
 
 add_subdirectory(deps/dice)
 find_package(libvsync 4.2 CONFIG)


### PR DESCRIPTION
In the upcoming Dice version, memset replacement is disabled by default. This commit sets DICE_MEMSET option in CMakeLists proactively so that once the new version arrives, we do not break the pipeline.