### PR TITLE
fix: gcc 15 warning/error in test case

### DIFF
--- a/test/trace_create_join.c
+++ b/test/trace_create_join.c
@@ -23,8 +23,9 @@ struct expected_entry expected_2[] = {
 };
 
 void *
-run()
+run(void *arg)
 {
+    (void)arg;
     return 0;
 }
 


### PR DESCRIPTION
Small issue when building with gcc 15.