### PR TITLE
Upgrade OpenHarmony SDK in OHOS workflow

### DIFF
--- a/.github/workflows/actions-benchmark.yaml
+++ b/.github/workflows/actions-benchmark.yaml
@@ -24,7 +24,7 @@ jobs:
       
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/actions-ohos.yml
+++ b/.github/workflows/actions-ohos.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           version: "6.0"
           fixup-path: true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: 'recursive'

--- a/.github/workflows/actions-ohos.yml
+++ b/.github/workflows/actions-ohos.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Setup OpenHarmony SDK
         id: setup_sdk
-        uses: openharmony-rs/setup-ohos-sdk@v0.2.4
+        uses: openharmony-rs/setup-ohos-sdk@v1.0.0
         with:
           version: "6.0"
           fixup-path: true

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -19,12 +19,12 @@ jobs:
           cxx: clang++
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Checkout Dice
         if: ${{ github.event_name == 'repository_dispatch' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: open-s4c/dice
           ref: ${{ github.event.client_payload.commit }}
@@ -46,7 +46,7 @@ jobs:
   check-format:
     runs-on: ubuntu-24.04
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
           with:
             submodules: recursive
         - name: Check clang-format version
@@ -60,7 +60,7 @@ jobs:
   check-linter:
     runs-on: ubuntu-24.04
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
           with:
             submodules: recursive
         - name: Check clang-tidy version
@@ -77,7 +77,7 @@ jobs:
     needs: test-linux
     steps:
       - name: Checkout Dice
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: open-s4c/dice
           ref: ${{ github.event.client_payload.commit }}


### PR DESCRIPTION
The OHOS workflow uses another action to obtain the OpenHarmony SDK. This action uses actions that run on node 20 which is deprecated by github from 16th of June 2026. Thjs commit upgrades the OHOS SDK version such that it uses node 24.