### PR TITLE
Improve CI workflow for benchmarks

### DIFF
--- a/.github/workflows/actions-benchmark.yaml
+++ b/.github/workflows/actions-benchmark.yaml
@@ -23,64 +23,59 @@ jobs:
       contents: read
       
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
-
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y miller hyperfine cmake make python3
 
-      - name: Download previous benchmark results from main
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Find the last successful workflow run ID on the main branch
-          LAST_RUN=$(gh run list --branch main --workflow "Run Benchmarks" --status success --json databaseId --jq '.[0].databaseId')
-          
-          if [ -n "$LAST_RUN" ] && [ "$LAST_RUN" != "null" ]; then
-            echo "Found previous successful run on main: $LAST_RUN"
-            gh run download $LAST_RUN --name "results-${{ matrix.os }}-${{ matrix.cfg.cc }}" --dir previous_results || echo "No previous artifact found."
-          else
-            echo "No previous successful run found on the main branch."
-          fi
+      - name: Checkout current code
+        uses: actions/checkout@v6
+        with:
+          path: current
+          submodules: recursive
 
-      - name: Build project
+      - name: Checkout main branch (Baseline)
+        if: github.event_name == 'pull_request' || github.ref != 'refs/heads/main'
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          path: baseline
+          submodules: recursive
+
+      - name: Build and Benchmark Baseline
+        if: github.event_name == 'pull_request' || github.ref != 'refs/heads/main'
+        working-directory: ./baseline
         run: |
           cmake -S . -Bbuild \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_COMPILER=${{ matrix.cfg.cc }} \
             -DCMAKE_CXX_COMPILER=${{ matrix.cfg.cxx }}
           cmake --build build
-
-      - name: Run benchmark script
-        run: |
           chmod +x scripts/benchmark.sh
           ./scripts/benchmark.sh --config --build --force-run --force-sum
 
-      - name: Print current summary to GitHub Actions
+      - name: Build and Benchmark Current Code
+        working-directory: ./current
+        run: |
+          cmake -S . -Bbuild \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=${{ matrix.cfg.cc }} \
+            -DCMAKE_CXX_COMPILER=${{ matrix.cfg.cxx }}
+          cmake --build build
+          chmod +x scripts/benchmark.sh
+          ./scripts/benchmark.sh --config --build --force-run --force-sum
+
+      - name: Print summary to GitHub Actions
+        working-directory: ./current
         run: |
           SUMMARY_FILE=$(ls results/bench-*.md | head -n 1)
           cat "$SUMMARY_FILE" >> $GITHUB_STEP_SUMMARY
 
       - name: Compare Benchmarks
+        if: github.event_name == 'pull_request' || github.ref != 'refs/heads/main'
         run: |
-          if [ -d "previous_results" ]; then
-            PREV_SUMMARY=$(ls previous_results/bench-*.md | head -n 1)
-            CURR_SUMMARY=$(ls results/bench-*.md | head -n 1)
+          PREV_SUMMARY=$(ls baseline/results/bench-*.md | head -n 1)
+          CURR_SUMMARY=$(ls current/results/bench-*.md | head -n 1)
 
-            echo "Comparing $PREV_SUMMARY against $CURR_SUMMARY"  
-            python3 scripts/bench-comparison.py "$PREV_SUMMARY" "$CURR_SUMMARY" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "Skipping comparison: No previous baseline from main available for this matrix configuration."
-          fi
-
-      - name: Save current results as Artifact (Main branch only)
-        uses: actions/upload-artifact@v4
-        if: github.ref == 'refs/heads/main' && success()
-        with:
-          name: "results-${{ matrix.os }}-${{ matrix.cfg.cc }}"
-          path: results/
-          overwrite: true
+          echo "Comparing $PREV_SUMMARY against $CURR_SUMMARY"  
+          python3 current/scripts/bench-comparison.py "$PREV_SUMMARY" "$CURR_SUMMARY" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/actions-benchmark.yaml
+++ b/.github/workflows/actions-benchmark.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   benchmark:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-24.04, ubuntu-22.04]
         cfg:
@@ -16,6 +17,7 @@ jobs:
             cxx: g++
           - cc: clang
             cxx: clang++
+        benchmark: [leveldb, raytracing, scratchapixel]
     runs-on: ${{ matrix.os }}
 
     permissions:
@@ -52,7 +54,7 @@ jobs:
             -DCMAKE_CXX_COMPILER=${{ matrix.cfg.cxx }}
           cmake --build build
           chmod +x scripts/benchmark.sh
-          ./scripts/benchmark.sh --config --build --force-run --force-sum
+          ./scripts/benchmark.sh --config --build --force-run --force-sum ${{ matrix.benchmark }}
 
       - name: Build and Benchmark Current Code
         working-directory: ./current
@@ -63,7 +65,7 @@ jobs:
             -DCMAKE_CXX_COMPILER=${{ matrix.cfg.cxx }}
           cmake --build build
           chmod +x scripts/benchmark.sh
-          ./scripts/benchmark.sh --config --build --force-run --force-sum
+          ./scripts/benchmark.sh --config --build --force-run --force-sum ${{ matrix.benchmark }}
 
       - name: Print summary to GitHub Actions
         working-directory: ./current

--- a/bench/common.mk
+++ b/bench/common.mk
@@ -37,4 +37,4 @@ PARSE=      awk -v tgt=$* '/Time/ && /mean/ { \
             }' $(WORKDIR)/$*.run.log | sed 's/ /;/g' | tee -a $(WORKDIR)/results.csv
 
 # Add TARGET+=header to initialize the results.csv file
-PRO.header=	echo 'variant; time_ms; stddev' > $(WORKDIR)/results.csv
+PRO.header=	echo 'variant; time_ms; stddev_ms' > $(WORKDIR)/results.csv

--- a/bench/common.mk
+++ b/bench/common.mk
@@ -24,7 +24,7 @@ LDFLAGS!=	if [ "$(CXX)" = "clang++" ]; then echo '-shared-libsan'; fi
 
 # For testing we use hyperfine if available, otherwise simply call command
 TESTER!=	if which hyperfine > /dev/null; \
-		then echo "hyperfine"; \
+		then echo "hyperfine --warmup 1"; \
 		else echo "sh -c"; fi
 
 # If hyperfine is used, we can parse the results with the following command

--- a/bench/common.mk
+++ b/bench/common.mk
@@ -28,12 +28,13 @@ TESTER!=	if which hyperfine > /dev/null; \
 		else echo "sh -c"; fi
 
 # If hyperfine is used, we can parse the results with the following command
-PARSE=		cat $(WORKDIR)/$*.run.log \
-		| grep Time | tr -s ' ' \
-		| cut -d' ' -f6,9 \
-		| tr ' ' '\;' \
-		| xargs -n1 echo "$*"';' \
-		| tee -a $(WORKDIR)/results.csv
+PARSE=      awk -v tgt=$* '/Time/ && /mean/ { \
+                m = \$$\$$5; \
+                if (\$$\$$6 ~ /^s\$$\$$/) m = m * 1000; \
+                s = \$$\$$8; \
+                if (\$$\$$9 ~ /^s\$$\$$/) s = s * 1000; \
+                print tgt, m, s \
+            }' $(WORKDIR)/$*.run.log | sed 's/ /;/g' | tee -a $(WORKDIR)/results.csv
 
 # Add TARGET+=header to initialize the results.csv file
 PRO.header=	echo 'variant; time_ms; stddev' > $(WORKDIR)/results.csv

--- a/bench/leveldb/Makefile
+++ b/bench/leveldb/Makefile
@@ -6,12 +6,7 @@
 # ------------------------------------------------------------------------------
 DBDIR=		/tmp/bench.db
 COMMAND=	./db_bench --db=$(DBDIR)
-RUNCMD= 	$(COMMAND) --threads=1 --benchmarks=readrandom --duration=10
-PARSECMD=	cat $(WORKDIR)/$*.run.log  \
-		| grep benchstats \
-		| cut -d: -f2 \
-		| xargs -n1 echo "$*"';' \
-		| tee -a $(WORKDIR)/results.csv
+RUNCMD= 	$(COMMAND) --threads=1 --benchmarks=readrandom --reads=500000
 BUNDLE_DIR=	$(PROJECT)/build/bench/lib/
 
 # ------------------------------------------------------------------------------
@@ -54,9 +49,6 @@ TARGET+=	populate
 DIR.populate=	$(DIR.vanilla)
 RUN.populate= 	rm -rf $(DBDIR) && $(COMMAND) --threads=1 --benchmarks=fillseq
 
-TARGET+=	results
-PRO.results=	echo 'variant; time_s; count; count_1' > $(WORKDIR)/results.csv
-
 TSAN_ASLR_WORKAROUND := $(shell \
     if [ "$$(uname -s)" = "Linux" ] && \
        uname -r | awk -F. '{if ($$1 > 6 || ($$1 == 6 && $$2 >= 6)) exit 0; else exit 1}'; then \
@@ -67,18 +59,19 @@ TSAN_ASLR_WORKAROUND := $(shell \
 # ------------------------------------------------------------------------------
 # Variants
 # ------------------------------------------------------------------------------
+TARGET+=	header
 
 TARGET+=	baseline
 DEP.baseline=	.populate.run
 DIR.baseline=	$(DIR.vanilla)
-RUN.baseline= 	env $(RUNCMD)
-PRO.baseline=	$(PARSECMD)
+RUN.baseline= 	$(TESTER) '$(RUNCMD)'
+PRO.baseline=	$(PARSE)
 
 TARGET+=	tsan
 DEP.tsan=	.populate.run
 DIR.tsan=	$(DIR.sanitized)
-RUN.tsan=	env TSAN_OPTIONS=report_bugs=0 $(TSAN_ASLR_WORKAROUND) $(RUNCMD)
-PRO.tsan=	$(PARSECMD)
+RUN.tsan=	$(TESTER) 'env TSAN_OPTIONS=report_bugs=0 $(TSAN_ASLR_WORKAROUND) $(RUNCMD)'
+PRO.tsan=	$(PARSE)
 # Linux: if TSAN fails with "FATAL: ThreadSanitizer: unexpected memory mapping"
 # Try running this
 #	sudo sysctl vm.mmap_rnd_bits=30
@@ -86,23 +79,23 @@ PRO.tsan=	$(PARSECMD)
 TARGET+=	tsano
 DEP.tsano=	.populate.run
 DIR.tsano=	$(DIR.sanitized)
-RUN.tsano=	env TSANO_LIBDIR=$(TSANO_LIBDIR) $(TSANO_CMD) $(RUNCMD)
-PRO.tsano=	$(PARSECMD)
+RUN.tsano=	$(TESTER) 'env TSANO_LIBDIR=$(TSANO_LIBDIR) $(TSANO_CMD) $(RUNCMD)'
+PRO.tsano=	$(PARSE)
 
 TARGET+=	coldtrace
 DEP.coldtrace=	.populate.run
 DIR.coldtrace=	$(DIR.sanitized)
 DIR.coldtrace=	$(DIR.tsan)
-RUN.coldtrace=	env $(COLDTRACE_CMD) $(RUNCMD)
-PRO.coldtrace=	$(PARSECMD)
+RUN.coldtrace=	$(TESTER) 'env $(COLDTRACE_CMD) $(RUNCMD)'
+PRO.coldtrace=	$(PARSE)
 
 TARGET+=	nowrites
 DEP.nowrites=	.populate.run
 DIR.nowrites=	$(DIR.sanitized)
 DIR.nowrites=	$(DIR.tsan)
-RUN.nowrites=	env COLDTRACE_DISABLE_WRITES=true \
-			$(COLDTRACE_CMD) $(RUNCMD)
-PRO.nowrites=	$(PARSECMD)
+RUN.nowrites=	$(TESTER) 'env COLDTRACE_DISABLE_WRITES=true \
+			$(COLDTRACE_CMD) $(RUNCMD)'
+PRO.nowrites=	$(PARSE)
 
 # file to build internal tool (freezer)
 # assumes libfreeze.so to be in the current directory
@@ -110,9 +103,9 @@ PRO.nowrites=	$(PARSECMD)
 DEP.freezer=	.populate.run
 DIR.freezer=	$(DIR.sanitized)
 DIR.freezer=	$(DIR.tsan)
-RUN.freezer=	env FREEZER_TRACE_PATH=traces \
-			LD_PRELOAD=$(ROOTDIR)/libfreeze.so $(RUNCMD)
-PRO.freezer=	$(PARSECMD)
+RUN.freezer=	FREEZER_TRACE_PATH=traces $(TESTER) \
+		'env LD_PRELOAD=$(ROOTDIR)/libfreeze.so $(RUNCMD)'
+PRO.freezer=	$(PARSE)
 
 # ------------------------------------------------------------------------------
 BENCHMK= ../bench.mk

--- a/scripts/bench-comparison.py
+++ b/scripts/bench-comparison.py
@@ -67,14 +67,9 @@ def compare_benchmarks(prev_data, curr_data):
             if (benchmark in prev_data and variant in prev_data[benchmark] 
                 and variant in CHECK_VARIANTS):
                 
-                if benchmark.lower() == "leveldb":
-                    prev_count = prev_data[benchmark][variant].get("count", 0)
-                    curr_count = curr_data[benchmark][variant].get("count", 0)
-                    speedup = curr_count / prev_count if prev_count > 0 else float('inf')
-                else:
-                    prev_time = prev_data[benchmark][variant].get("time_ms", 0)
-                    curr_time = curr_data[benchmark][variant].get("time_ms", 0)
-                    speedup = prev_time / curr_time if curr_time > 0 else float('inf')
+                prev_time = prev_data[benchmark][variant].get("time_ms", 0)
+                curr_time = curr_data[benchmark][variant].get("time_ms", 0)
+                speedup = prev_time / curr_time if curr_time > 0 else float('inf')
 
                 comparison[benchmark][variant] = {
                     "speedup": speedup,


### PR DESCRIPTION
This PR improves the reliability of the benchmarking pipeline by running direct branch comparisons and standardizing all tests to use hyperfine.

**What Changed:**
- Checks out and builds both `main` and the current branch, running them sequentially on the exact same CI runner to eliminate hardware differences.
- Added `leveldb`, `raytracing`, and `scratchapixel` to the CI matrix so they run in parallel, speeding up CI execution.
- Switched the `leveldb` benchmark from a duration-based run (`--duration=10`) to a fixed workload (`--reads=500000`) and migrated it to use hyperfine.
- Refactored the way results from `hyperfine` are parsed to correctly handle `ms` and `s` units.