### PR TITLE
fix: switch to abort() on OHOS for fatal errors

### DIFF
--- a/include/coldtrace/log.h
+++ b/include/coldtrace/log.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2025 Huawei Technologies Co., Ltd.
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef COLDTRACE_LOGS_H
+#define COLDTRACE_LOGS_H
+#include <dice/log.h>
+
+#undef log_fatal
+
+#if defined(__OHOS__)
+    #define LOG_FATAL_TERMINATE() abort()
+#else
+    #define LOG_FATAL_TERMINATE() exit(EXIT_FAILURE)
+#endif
+
+/* log_fatal prints the message and exits with EXIT_FAILURE if the system is not
+ * OHOS. If the system is OHOS, it prints the message and aborts the program.
+ *
+ * It indicates a fatal error was detected, but it is a possibly expected error
+ */
+#define log_fatal(fmt, ...)                                                    \
+    do {                                                                       \
+        LOG_LOCK_ACQUIRE;                                                      \
+        log_printf(LOG_PREFIX);                                                \
+        log_printf(fmt, ##__VA_ARGS__);                                        \
+        log_printf(LOG_SUFFIX);                                                \
+        LOG_LOCK_RELEASE;                                                      \
+        LOG_FATAL_TERMINATE();                                                 \
+    } while (0)
+
+#endif // COLDTRACE_LOGS_H

--- a/src/config.c
+++ b/src/config.c
@@ -4,8 +4,8 @@
  */
 
 #include <coldtrace/config.h>
+#include <coldtrace/log.h>
 #include <coldtrace/utils.h>
-#include <dice/log.h>
 #include <dice/module.h>
 #include <string.h>
 

--- a/src/entries.c
+++ b/src/entries.c
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 #include <coldtrace/entries.h>
-#include <dice/log.h>
+#include <coldtrace/log.h>
 #include <stdbool.h>
 #include <stddef.h>
 

--- a/src/procmaps.c
+++ b/src/procmaps.c
@@ -5,6 +5,7 @@
 
 #include <coldtrace/aliases.h>
 #include <coldtrace/config.h>
+#include <coldtrace/log.h>
 #include <coldtrace/utils.h>
 #include <dice/chains/capture.h>
 #include <dice/events/thread.h>

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -5,9 +5,9 @@
 
 extern "C" {
 #include <coldtrace/config.h>
+#include <coldtrace/log.h>
 #include <coldtrace/thread.h>
 #include <coldtrace/writer.h>
-#include <dice/log.h>
 #include <dice/module.h>
 #include <dice/pubsub.h>
 #include <dice/self.h>

--- a/src/utils.c
+++ b/src/utils.c
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include <coldtrace/log.h>
 #include <coldtrace/utils.h>
 #include <dice/compiler.h>
-#include <dice/log.h>
 #include <dirent.h>
 #include <errno.h>
 #include <ftw.h>

--- a/src/writer.c
+++ b/src/writer.c
@@ -1,8 +1,8 @@
 #include <coldtrace/config.h>
+#include <coldtrace/log.h>
 #include <coldtrace/version.h>
 #include <coldtrace/writer.h>
 #include <dice/compiler.h>
-#include <dice/log.h>
 #include <dice/mempool.h>
 #include <dice/self.h>
 #include <dice/types.h>

--- a/test/checkers/indexes_checker.c
+++ b/test/checkers/indexes_checker.c
@@ -2,7 +2,7 @@
  * Copyright (C) 2026 Huawei Technologies Co., Ltd.
  * SPDX-License-Identifier: MIT
  */
-#include <dice/log.h>
+#include <coldtrace/log.h>
 #include <dice/mempool.h>
 #include <indexes_checker.h>
 #include <string.h>

--- a/test/checkers/trace_checker.c
+++ b/test/checkers/trace_checker.c
@@ -15,11 +15,11 @@
 #include <assert.h>
 #include <coldtrace/config.h>
 #include <coldtrace/entries.h>
+#include <coldtrace/log.h>
 #include <coldtrace/version.h>
 #include <dice/chains/capture.h>
 #include <dice/ensure.h>
 #include <dice/interpose.h>
-#include <dice/log.h>
 #include <dice/module.h>
 #include <dice/self.h>
 #include <dice/types.h>

--- a/test/trace_alloc_free.c
+++ b/test/trace_alloc_free.c
@@ -1,8 +1,7 @@
-#include <dice/log.h>
+#include <coldtrace/log.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <trace_checker.h>
-
 
 struct expected_entry expected_1[] = {
 

--- a/test/trace_calloc.c
+++ b/test/trace_calloc.c
@@ -1,4 +1,4 @@
-#include <dice/log.h>
+#include <coldtrace/log.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <trace_checker.h>

--- a/test/trace_create_join.c
+++ b/test/trace_create_join.c
@@ -1,5 +1,5 @@
 #include <assert.h>
-#include <dice/log.h>
+#include <coldtrace/log.h>
 #include <pthread.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/test/trace_lock_unlock.c
+++ b/test/trace_lock_unlock.c
@@ -1,4 +1,4 @@
-#include <dice/log.h>
+#include <coldtrace/log.h>
 #include <pthread.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/test/trace_main_close.c
+++ b/test/trace_main_close.c
@@ -1,5 +1,5 @@
+#include <coldtrace/log.h>
 #include <dice/ensure.h>
-#include <dice/log.h>
 #include <stdbool.h>
 #include <trace_checker.h>
 

--- a/test/trace_mman.c
+++ b/test/trace_mman.c
@@ -1,4 +1,4 @@
-#include <dice/log.h>
+#include <coldtrace/log.h>
 #include <sys/mman.h>
 #include <trace_checker.h>
 

--- a/test/trace_pthread_cond_clockwait.c
+++ b/test/trace_pthread_cond_clockwait.c
@@ -1,4 +1,4 @@
-#include <dice/log.h>
+#include <coldtrace/log.h>
 #include <errno.h>
 #include <pthread.h>
 #include <time.h>

--- a/test/trace_pthread_mutex_clocklock.c
+++ b/test/trace_pthread_mutex_clocklock.c
@@ -1,4 +1,4 @@
-#include <dice/log.h>
+#include <coldtrace/log.h>
 #include <errno.h>
 #include <pthread.h>
 #include <time.h>

--- a/test/trace_pthread_rwlock.c
+++ b/test/trace_pthread_rwlock.c
@@ -1,4 +1,4 @@
-#include <dice/log.h>
+#include <coldtrace/log.h>
 #include <pthread.h>
 #include <trace_checker.h>
 

--- a/test/trace_pthread_spinlock.c
+++ b/test/trace_pthread_spinlock.c
@@ -1,4 +1,4 @@
-#include <dice/log.h>
+#include <coldtrace/log.h>
 #include <pthread.h>
 #include <trace_checker.h>
 

--- a/test/trace_read_write_range.c
+++ b/test/trace_read_write_range.c
@@ -1,4 +1,4 @@
-#include <dice/log.h>
+#include <coldtrace/log.h>
 #include <pthread.h>
 #include <trace_checker.h>
 

--- a/test/trace_read_write_size.c
+++ b/test/trace_read_write_size.c
@@ -1,4 +1,4 @@
-#include <dice/log.h>
+#include <coldtrace/log.h>
 #include <trace_checker.h>
 
 struct expected_entry expected_1[] = {

--- a/test/trace_write_var.c
+++ b/test/trace_write_var.c
@@ -1,6 +1,6 @@
 #include "trace_checker.h"
 
-#include <dice/log.h>
+#include <coldtrace/log.h>
 #include <pthread.h>
 #include <stdbool.h>
 #include <stddef.h>


### PR DESCRIPTION
This PR fixes a deadlock occurring on OpenHarmony when a fatal error is detected during process shutdown. Previously, `log_fatal()` called `exit()`, which caused a deadlock in musl's exit mutex if called concurrently with the main program's exit sequence. By using abort() on OHOS, we bypass the exit handler, allowing the process to terminate immediately.

### Changes
- Replaced `exit(EXIT_FAILURE)` with `abort()` within `log_fatal` specifically for OpenHarmony builds.

> **_Note:_** This is a temporary solution for issue #118.