### PR TITLE
feat: add TEST_MARKER event for improving trace checking

### DIFF
--- a/include/coldtrace/entries.h
+++ b/include/coldtrace/entries.h
@@ -39,7 +39,8 @@
 #define COLDTRACE_FENCE             21
 #define COLDTRACE_MMAP              22
 #define COLDTRACE_MUNMAP            23
-#define COLDTRACE_END_              24
+#define COLDTRACE_TEST_MARKER       24
+#define COLDTRACE_END_              25
 
 typedef uint8_t coldtrace_entry_type;
 
@@ -80,6 +81,10 @@ struct coldtrace_stack_diff {
     uint32_t popped;
     uint32_t depth;
     uint64_t diff[];
+};
+
+struct coldtrace_marker_entry {
+    struct coldtrace_entry_header _;
 };
 
 struct coldtrace_access_entry {

--- a/include/coldtrace/marker.h
+++ b/include/coldtrace/marker.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2026 Huawei Technologies Co., Ltd.
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef COLDTRACE_MARKER_H
+#define COLDTRACE_MARKER_H
+
+#define EVENT_TEST_MARKER 103
+
+struct coldtrace_marker_event {
+    const void *pc;
+    int ret;
+};
+
+#endif /* COLDTRACE_MARKER_H */

--- a/scripts/ohos-runner.py
+++ b/scripts/ohos-runner.py
@@ -175,6 +175,7 @@ def transfer_core_libs(device):
         ("deps/dice/deps/tsano/libtsano.so", "libtsano.so"),
         ("test/libtrace_checker.so", "libtrace_checker.so"),
         ("test/libmock_checker.so", "libmock_checker.so"),
+        ("test/libmarker.so", "libmarker.so")
     ]
     
     for local_path, remote_name in libs:

--- a/scripts/trace_dump.py
+++ b/scripts/trace_dump.py
@@ -74,6 +74,7 @@ class EntryType(Enum):
     FENCE   = 21
     MMAP    = 22
     MUNMAP  = 23
+    TEST_MARKER = 24
 
 ZERO_FLAG = 0b10000000
 PTR_MASK = 0x0000_FFFF_FFFF_FFFF
@@ -181,6 +182,9 @@ for f in file_list:
             elif (entry_type.value == 4 or entry_type.value == 5): # ATOMIC_READ & ATOMIC_WRITE
                 raw_ext = file.read(COLD_ATOMIC_ACCESS_ENTRY_SZ - COLD_BASE_ENTRY_SZ)
                 size, atomic_timestamp = struct.unpack('<QQ', raw_ext)
+            elif (entry_type.value == 24):
+                # TEST_MARKER entry has no additional data
+                pass
             else:
                 atomic_timestamp, = struct.unpack('<Q', file.read(COLD_ATOMIC_ENTRY_SZ - COLD_BASE_ENTRY_SZ))
 
@@ -228,6 +232,8 @@ for f in file_list:
                     print(f"{nentries}) {tid}: rw_lock rel @{ptr:x} [{atomic_timestamp}]\n")
                 case EntryType.FENCE:
                     print(f"{nentries}) {tid}: fence [{atomic_timestamp}]\n")
+                case EntryType.TEST_MARKER:
+                    print(f"{nentries}) {tid}: test marker\n")
                 case EntryType.CXA_GUARD_ACQUIRE:
                     print(f"{nentries}) {tid}: acquire cxa_guard @{ptr:x} [{atomic_timestamp}]\n")
                 case EntryType.CXA_GUARD_RELEASE:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,8 @@ math(EXPR SLOT_subs_cxa "${COLDTRACE_BASE_SLOT} + 7")
 math(EXPR SLOT_subs_mman "${COLDTRACE_BASE_SLOT} + 8")
 math(EXPR SLOT_subs_annotate_rwlock "${COLDTRACE_BASE_SLOT} + 9")
 math(EXPR SLOT_subs_memcpy "${COLDTRACE_BASE_SLOT} + 10")
+math(EXPR SLOT_subs_marker "${COLDTRACE_BASE_SLOT} + 11")
+math(EXPR SLOT_marker "${COLDTRACE_BASE_SLOT} + 12")
 
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION true)
 
@@ -27,7 +29,8 @@ set(SRCS
     utils.c
     writer.c
     entries.c
-    version.c)
+    version.c
+    marker.c)
 
 # subscribers
 set(SRCS
@@ -36,6 +39,7 @@ set(SRCS
     subs_tsan.c
     subs_pthread.c
     subs_malloc.c
+    subs_marker.c
     subs_mman.c
     subs_memcpy.c
     subs_cxa.c

--- a/src/entries.c
+++ b/src/entries.c
@@ -33,6 +33,7 @@ static const char *type_map_[] = {
     TYPE_MAP(COLDTRACE_FENCE),
     TYPE_MAP(COLDTRACE_MMAP),
     TYPE_MAP(COLDTRACE_MUNMAP),
+    TYPE_MAP(COLDTRACE_TEST_MARKER),
 };
 
 static inline bool
@@ -175,6 +176,11 @@ coldtrace_entry_get_size(const void *buf)
             next += sizeof(struct coldtrace_atomic_entry);
         } break;
 
+        case COLDTRACE_TEST_MARKER: {
+            const struct coldtrace_marker_entry *e = buf;
+            next += sizeof(struct coldtrace_marker_entry);
+        } break;
+
         default:
             log_fatal("Unknown entry size");
             break;
@@ -208,6 +214,7 @@ static const size_t space_map_[] = {
     [COLDTRACE_FENCE]             = sizeof(struct coldtrace_atomic_entry),
     [COLDTRACE_THREAD_CREATE]     = sizeof(struct coldtrace_atomic_entry),
     [COLDTRACE_THREAD_START]      = sizeof(struct coldtrace_thread_init_entry),
+    [COLDTRACE_TEST_MARKER]       = sizeof(struct coldtrace_marker_entry),
 };
 
 size_t

--- a/src/marker.c
+++ b/src/marker.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2026 Huawei Technologies Co., Ltd.
+ * SPDX-License-Identifier: MIT
+ */
+#include <coldtrace/marker.h>
+#include <dice/chains/intercept.h>
+#include <dice/interpose.h>
+#include <dice/module.h>
+#include <dice/self.h>
+
+INTERPOSE(int, coldtrace_test_marker)
+{
+    struct coldtrace_marker_event ev = {
+        .pc  = INTERPOSE_PC,
+        .ret = 0,
+    };
+    struct metadata md = {0};
+
+    PS_PUBLISH(INTERCEPT_EVENT, EVENT_TEST_MARKER, &ev, &md);
+
+    return ev.ret;
+}
+
+PS_ADVERTISE_TYPE(EVENT_TEST_MARKER)
+
+DICE_MODULE_INIT()

--- a/src/subs_marker.c
+++ b/src/subs_marker.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2026 Huawei Technologies Co., Ltd.
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <coldtrace/aliases.h>
+#include <coldtrace/counters.h>
+#include <coldtrace/marker.h>
+#include <coldtrace/thread.h>
+#include <dice/interpose.h>
+#include <dice/module.h>
+#include <dice/pubsub.h>
+
+DICE_MODULE_INIT()
+
+PS_SUBSCRIBE(CAPTURE_EVENT, EVENT_TEST_MARKER, {
+    struct coldtrace_marker_event *ev = EVENT_PAYLOAD(ev);
+    struct coldtrace_marker_entry *e =
+        coldtrace_thread_append(md, COLDTRACE_TEST_MARKER, 0);
+})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,8 @@ target_link_libraries(trace_checker PUBLIC vsync dice.h ${COLDTRACE_OBJS})
 add_library(mock_checker SHARED checkers/mock_checker.c)
 target_link_libraries(mock_checker PUBLIC vsync dice.h)
 
+add_library(marker SHARED checkers/marker.c)
+
 set(OPTIONS_atomic_test -ensure-traces)
 set(OPTIONS_spinlock -ensure-traces)
 
@@ -20,7 +22,7 @@ foreach(SRC ${SRCS})
   set(TRACES_DIR "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}__traces")
 
   add_executable(${TARGET} ${SRC})
-  target_link_libraries(${TARGET} PRIVATE dice.h vsync pthread)
+  target_link_libraries(${TARGET} PRIVATE dice.h vsync pthread marker)
 
   # handle instrumentation and linking of target against TSAN
   target_compile_options(${TARGET} PRIVATE -fsanitize=thread)

--- a/test/checkers/marker.c
+++ b/test/checkers/marker.c
@@ -1,0 +1,10 @@
+/*
+ * Copyright (C) 2026 Huawei Technologies Co., Ltd.
+ * SPDX-License-Identifier: MIT
+ */
+
+int
+coldtrace_test_marker()
+{
+    return 0;
+}

--- a/test/checkers/marker.h
+++ b/test/checkers/marker.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2026 Huawei Technologies Co., Ltd.
+ * SPDX-License-Identifier: MIT
+ */
+#ifndef MARKER_FUNC_H
+#define MARKER_FUNC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int coldtrace_test_marker();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MARKER_FUNC_H */

--- a/test/trace_alloc_free.c
+++ b/test/trace_alloc_free.c
@@ -1,10 +1,12 @@
 #include <coldtrace/log.h>
+#include <marker.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <trace_checker.h>
 
 struct expected_entry expected_1[] = {
 
+    EXPECT_SUFFIX(COLDTRACE_TEST_MARKER),
     EXPECT_VALUE(COLDTRACE_ALLOC, 0),
     EXPECT_SOME_VALUE(COLDTRACE_FREE, 0, 1, 0),
     EXPECT_SOME_VALUE(COLDTRACE_ALLOC, 0, 1, 1),
@@ -18,6 +20,8 @@ int
 main()
 {
     register_expected_trace(1, expected_1);
+    coldtrace_test_marker();
+
     int *ptr1;
     ptr1 = malloc(sizeof(*ptr1));
 

--- a/test/trace_annotate_rwlock.c
+++ b/test/trace_annotate_rwlock.c
@@ -1,5 +1,5 @@
+#include <marker.h>
 #include <trace_checker.h>
-
 
 void AnnotateRWLockCreate(const char *file, int line,
                           const volatile void *lock);
@@ -12,6 +12,7 @@ void AnnotateRWLockReleased(const char *file, int line,
 
 
 struct expected_entry expected_1[] = {
+    EXPECT_SUFFIX(COLDTRACE_TEST_MARKER),
     EXPECT_SOME(COLDTRACE_ALLOC, 0, 1),
     EXPECT_SOME(COLDTRACE_FREE, 0, 1),
     EXPECT_VALUE(COLDTRACE_RW_LOCK_CREATE, 0),
@@ -28,6 +29,7 @@ int
 main()
 {
     register_expected_trace(1, expected_1);
+    coldtrace_test_marker();
     void *lock = (void *)0x42; // NOLINT
     AnnotateRWLockCreate(__FILE__, __LINE__, lock);
     AnnotateRWLockAcquired(__FILE__, __LINE__, lock, 0);

--- a/test/trace_aread_awrite_size.cpp
+++ b/test/trace_aread_awrite_size.cpp
@@ -1,11 +1,12 @@
 #include <atomic>
 #include <cstdio>
 #include <cstdlib>
+#include <marker.h>
 #include <trace_checker.h>
 
 struct expected_entry expected_1[] = {
 
-    EXPECT_SUFFIX(COLDTRACE_FENCE),
+    EXPECT_SUFFIX(COLDTRACE_TEST_MARKER),
 
     EXPECT_VALUE_SIZE(COLDTRACE_ATOMIC_WRITE, 0, sizeof(uint8_t)),
     EXPECT_VALUE_SIZE(COLDTRACE_ATOMIC_READ, 0, sizeof(uint8_t)),
@@ -48,6 +49,7 @@ int
 main(void)
 {
     register_expected_trace(1, expected_1);
+    coldtrace_test_marker();
 
     std::atomic<uint8_t> at_8;
     std::atomic<uint16_t> at_16;
@@ -55,8 +57,6 @@ main(void)
     std::atomic<uint64_t> at_64;
     std::atomic<float> at_float;
     std::atomic<double> at_double;
-
-    std::atomic_thread_fence(std::memory_order_release); // fence
 
     at_8.store(VALUE, std::memory_order_release);         // write
     uint8_t val_8 = at_8.load(std::memory_order_acquire); // read

--- a/test/trace_atomic.cpp
+++ b/test/trace_atomic.cpp
@@ -1,6 +1,7 @@
 #include <atomic>
 #include <cstdio>
 #include <cstdlib>
+#include <marker.h>
 #include <pthread.h>
 #include <trace_checker.h>
 
@@ -14,6 +15,7 @@
         EXPECT_SOME_SIZE(COLDTRACE_WRITE, 0, 1, sizeof(uint8_t))
 
 struct expected_entry expected_1[] = {
+    EXPECT_SUFFIX(COLDTRACE_TEST_MARKER),
     EXPECT_SOME_VALUE(COLDTRACE_ALLOC, 0, 1, 0),
     EXPECT_SOME_VALUE(COLDTRACE_WRITE, 0, 1, 0),
     EXPECT_SOME_VALUE(COLDTRACE_FREE, 0, 1, 0),
@@ -108,6 +110,7 @@ main()
     register_expected_trace(2, expected_2);
     register_expected_trace(3, expected_3);
     register_expected_trace(4, expected_4);
+    coldtrace_test_marker();
 
     pthread_t threads[NUM_THREADS];
     pthread_t free_thread;

--- a/test/trace_calloc.c
+++ b/test/trace_calloc.c
@@ -1,4 +1,5 @@
 #include <coldtrace/log.h>
+#include <marker.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <trace_checker.h>
@@ -6,8 +7,7 @@
 #define N 5
 
 struct expected_entry expected_1[] = {
-
-    EXPECT_ENTRY(COLDTRACE_ALLOC),
+    EXPECT_SUFFIX(COLDTRACE_TEST_MARKER),
     EXPECT_VALUE_SIZE(COLDTRACE_ALLOC, 1, N * sizeof(int)),
     EXPECT_VALUE(COLDTRACE_FREE, 1),
     EXPECT_ENTRY(COLDTRACE_THREAD_EXIT),
@@ -18,6 +18,7 @@ int
 main()
 {
     register_expected_trace(1, expected_1);
+    coldtrace_test_marker();
 
     int *array;
     array = (int *)calloc(N, sizeof(int));

--- a/test/trace_create_join.c
+++ b/test/trace_create_join.c
@@ -1,13 +1,13 @@
 #include <assert.h>
 #include <coldtrace/log.h>
+#include <marker.h>
 #include <pthread.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <trace_checker.h>
 
 struct expected_entry expected_1[] = {
-    EXPECT_SOME(COLDTRACE_ALLOC, 0, 1),
-    EXPECT_SOME(COLDTRACE_FREE, 0, 1),
+    EXPECT_SUFFIX(COLDTRACE_TEST_MARKER),
     EXPECT_VALUE(COLDTRACE_THREAD_CREATE, 0),
     EXPECT_ENTRY(COLDTRACE_READ),
     EXPECT_VALUE(COLDTRACE_THREAD_JOIN, 0),
@@ -34,6 +34,7 @@ main()
 {
     register_expected_trace(1, expected_1);
     register_expected_trace(2, expected_2);
+    coldtrace_test_marker();
 
     pthread_t t;
     pthread_create(&t, 0, run, 0);

--- a/test/trace_cxa_guard.cpp
+++ b/test/trace_cxa_guard.cpp
@@ -1,3 +1,4 @@
+#include <marker.h>
 #include <sys/time.h>
 #include <thread>
 #include <trace_checker.h>
@@ -6,6 +7,7 @@
 #define NUM_THREADS 2
 
 struct expected_entry expected_1[] = {
+    EXPECT_SUFFIX(COLDTRACE_TEST_MARKER),
     EXPECT_SUFFIX_VALUE(COLDTRACE_THREAD_CREATE, 0),
     EXPECT_SUFFIX_VALUE(COLDTRACE_THREAD_JOIN, 0),
     EXPECT_SUFFIX_VALUE(COLDTRACE_THREAD_CREATE, 1),
@@ -51,6 +53,7 @@ main()
     register_expected_trace(1, expected_1);
     register_expected_trace(2, expected_2);
     register_expected_trace(3, expected_3);
+    coldtrace_test_marker();
     std::thread threads[NUM_THREADS];
 
 

--- a/test/trace_fail.c
+++ b/test/trace_fail.c
@@ -1,7 +1,9 @@
 #include "coldtrace/entries.h"
+#include "marker.h"
 #include "trace_checker.h"
 
 struct expected_entry expected[] = {
+    EXPECT_SUFFIX(COLDTRACE_TEST_MARKER),
     EXPECT_ENTRY(COLDTRACE_ATOMIC_READ),
     EXPECT_ENTRY(COLDTRACE_LOCK_ACQUIRE),
     EXPECT_SUFFIX(COLDTRACE_THREAD_EXIT),
@@ -12,5 +14,6 @@ int
 main()
 {
     register_expected_trace(1, expected);
+    coldtrace_test_marker();
     return 0;
 }

--- a/test/trace_fence.cpp
+++ b/test/trace_fence.cpp
@@ -1,5 +1,6 @@
 #include <atomic>
 #include <iostream>
+#include <marker.h>
 #include <pthread.h>
 #include <string>
 #include <trace_checker.h>
@@ -28,6 +29,7 @@ computation(int value)
 }
 
 struct expected_entry expected_1[] = {
+    EXPECT_SUFFIX(COLDTRACE_TEST_MARKER),
     EXPECT_SOME(COLDTRACE_ALLOC, 0, 1),
     EXPECT_SOME(COLDTRACE_FREE, 0, 1),
     EXPECT_SOME(COLDTRACE_WRITE, 0, 0),
@@ -126,6 +128,7 @@ main()
     register_expected_trace(1, expected_1);
     register_expected_trace(2, expected_2);
     register_expected_trace(3, expected_3);
+    coldtrace_test_marker();
     arr[0].store(-1);
     arr[1].store(-1);
     arr[2].store(-1);

--- a/test/trace_lock_unlock.c
+++ b/test/trace_lock_unlock.c
@@ -1,10 +1,12 @@
 #include <coldtrace/log.h>
+#include <marker.h>
 #include <pthread.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <trace_checker.h>
 
 struct expected_entry expected[] = {
+    EXPECT_SUFFIX(COLDTRACE_TEST_MARKER),
     EXPECT_SOME(COLDTRACE_ALLOC, 0, 1),
     EXPECT_SOME(COLDTRACE_FREE, 0, 1),
     EXPECT_SOME(COLDTRACE_WRITE, 0, 1),
@@ -18,6 +20,7 @@ int
 main()
 {
     register_expected_trace(1, expected);
+    coldtrace_test_marker();
 
     pthread_mutex_t l = PTHREAD_MUTEX_INITIALIZER;
     pthread_mutex_lock(&l);

--- a/test/trace_memcpy.c
+++ b/test/trace_memcpy.c
@@ -1,12 +1,13 @@
+#include <marker.h>
 #include <string.h>
 #include <trace_checker.h>
 
 struct expected_entry expected_1[] = {
-    EXPECT_ENTRY(COLDTRACE_ALLOC),       EXPECT_SOME(COLDTRACE_READ, 0, 1),
-    EXPECT_ENTRY(COLDTRACE_WRITE),       EXPECT_ENTRY(COLDTRACE_READ),
-    EXPECT_ENTRY(COLDTRACE_WRITE),       EXPECT_ENTRY(COLDTRACE_READ),
-    EXPECT_ENTRY(COLDTRACE_WRITE),       EXPECT_ENTRY(COLDTRACE_ALLOC),
-    EXPECT_ENTRY(COLDTRACE_THREAD_EXIT), EXPECT_END,
+    EXPECT_SUFFIX(COLDTRACE_TEST_MARKER), EXPECT_SOME(COLDTRACE_READ, 0, 1),
+    EXPECT_ENTRY(COLDTRACE_WRITE),        EXPECT_ENTRY(COLDTRACE_READ),
+    EXPECT_ENTRY(COLDTRACE_WRITE),        EXPECT_ENTRY(COLDTRACE_READ),
+    EXPECT_ENTRY(COLDTRACE_WRITE),        EXPECT_ENTRY(COLDTRACE_ALLOC),
+    EXPECT_ENTRY(COLDTRACE_THREAD_EXIT),  EXPECT_END,
 };
 
 #define STR_BUFFER_SIZE    100
@@ -24,6 +25,7 @@ int
 main(int argc, char **argv)
 {
     register_expected_trace(1, expected_1);
+    coldtrace_test_marker();
 
     char str[STR_BUFFER_SIZE] = "Learningisfun";
 

--- a/test/trace_mman.c
+++ b/test/trace_mman.c
@@ -1,19 +1,25 @@
 #include <coldtrace/log.h>
+#include <marker.h>
 #include <sys/mman.h>
 #include <trace_checker.h>
 
 #define PAGE_SIZE 4096
 
 struct expected_entry expected_1[] = {
-    EXPECT_SOME(COLDTRACE_ALLOC, 0, 1),  EXPECT_SOME(COLDTRACE_FREE, 0, 1),
-    EXPECT_VALUE(COLDTRACE_MMAP, 0),     EXPECT_VALUE(COLDTRACE_MUNMAP, 0),
-    EXPECT_ENTRY(COLDTRACE_THREAD_EXIT), EXPECT_END,
+    EXPECT_SUFFIX(COLDTRACE_TEST_MARKER),
+    EXPECT_SOME(COLDTRACE_ALLOC, 0, 1),
+    EXPECT_SOME(COLDTRACE_FREE, 0, 1),
+    EXPECT_VALUE(COLDTRACE_MMAP, 0),
+    EXPECT_VALUE(COLDTRACE_MUNMAP, 0),
+    EXPECT_ENTRY(COLDTRACE_THREAD_EXIT),
+    EXPECT_END,
 };
 
 int
 main(void)
 {
     register_expected_trace(1, expected_1);
+    coldtrace_test_marker();
     // mmap without a file
     void *ptr1 = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE,
                       MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);

--- a/test/trace_mutex_2.cpp
+++ b/test/trace_mutex_2.cpp
@@ -4,6 +4,7 @@
  */
 #include <cstdio>
 #include <iostream>
+#include <marker.h>
 #include <mutex>
 #include <pthread.h>
 #include <stdint.h>
@@ -49,6 +50,7 @@ once_plus_one(void *ptr)
 #define NUM_THREADS 1
 
 struct expected_entry expected_1[] = {
+    EXPECT_SUFFIX(COLDTRACE_TEST_MARKER),
     EXPECT_SOME(COLDTRACE_ALLOC, 0, 1),
     EXPECT_SOME(COLDTRACE_FREE, 0, 1),
     EXPECT_VALUE(COLDTRACE_WRITE, 1),
@@ -84,6 +86,7 @@ main()
 {
     register_expected_trace(1, expected_1);
     register_expected_trace(2, expected_2);
+    coldtrace_test_marker();
     uint8_t at = NotStarted;
     pthread_t threads[NUM_THREADS];
     for (int i = 0; i < NUM_THREADS; i++) {

--- a/test/trace_pthread_cond_clockwait.c
+++ b/test/trace_pthread_cond_clockwait.c
@@ -1,10 +1,12 @@
 #include <coldtrace/log.h>
 #include <errno.h>
+#include <marker.h>
 #include <pthread.h>
 #include <time.h>
 #include <trace_checker.h>
 
 struct expected_entry expected_1[] = {
+    EXPECT_SUFFIX(COLDTRACE_TEST_MARKER),
     EXPECT_ENTRY(COLDTRACE_ALLOC),
     EXPECT_VALUE(COLDTRACE_READ, 0),         // from gettime
     EXPECT_VALUE(COLDTRACE_WRITE, 0),        // from +=2
@@ -23,6 +25,7 @@ int
 main(void)
 {
     register_expected_trace(1, expected_1);
+    coldtrace_test_marker();
 
     pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
     pthread_cond_t c  = PTHREAD_COND_INITIALIZER;

--- a/test/trace_pthread_mutex_clocklock.c
+++ b/test/trace_pthread_mutex_clocklock.c
@@ -1,11 +1,12 @@
 #include <coldtrace/log.h>
 #include <errno.h>
+#include <marker.h>
 #include <pthread.h>
 #include <time.h>
 #include <trace_checker.h>
 
 struct expected_entry expected_1[] = {
-    EXPECT_ENTRY(COLDTRACE_ALLOC),
+    EXPECT_SUFFIX(COLDTRACE_TEST_MARKER),
     EXPECT_SOME_VALUE(COLDTRACE_READ, 0, 1, 0),     // from gettime
     EXPECT_SOME_VALUE(COLDTRACE_WRITE, 0, 1, 0),    // from +=2
     EXPECT_SUFFIX_VALUE(COLDTRACE_LOCK_ACQUIRE, 1), // from clocklock
@@ -21,6 +22,7 @@ int
 main(void)
 {
     register_expected_trace(1, expected_1);
+    coldtrace_test_marker();
 
     pthread_mutex_t m = PTHREAD_MUTEX_INITIALIZER;
 

--- a/test/trace_pthread_rwlock.c
+++ b/test/trace_pthread_rwlock.c
@@ -1,8 +1,10 @@
 #include <coldtrace/log.h>
+#include <marker.h>
 #include <pthread.h>
 #include <trace_checker.h>
 
 struct expected_entry expected_1[] = {
+    EXPECT_SUFFIX(COLDTRACE_TEST_MARKER),
     EXPECT_SOME(COLDTRACE_ALLOC, 0, 1),
     EXPECT_SOME(COLDTRACE_FREE, 0, 1),
     EXPECT_VALUE(COLDTRACE_RW_LOCK_ACQ_SHR, 0),
@@ -17,6 +19,7 @@ int
 main()
 {
     register_expected_trace(1, expected_1);
+    coldtrace_test_marker();
     pthread_rwlock_t lock;
     int p = pthread_rwlock_init(&lock, NULL);
 

--- a/test/trace_pthread_spinlock.c
+++ b/test/trace_pthread_spinlock.c
@@ -1,8 +1,10 @@
 #include <coldtrace/log.h>
+#include <marker.h>
 #include <pthread.h>
 #include <trace_checker.h>
 
 struct expected_entry expected[] = {
+    EXPECT_SUFFIX(COLDTRACE_TEST_MARKER),
     EXPECT_SOME(COLDTRACE_ALLOC, 0, 1),
     EXPECT_SOME(COLDTRACE_FREE, 0, 1),
     EXPECT_VALUE(COLDTRACE_LOCK_ACQUIRE, 0),
@@ -15,6 +17,7 @@ int
 main()
 {
     register_expected_trace(1, expected);
+    coldtrace_test_marker();
 
     pthread_spinlock_t l;
     if (pthread_spin_init(&l, PTHREAD_PROCESS_PRIVATE) != 0) {

--- a/test/trace_pthread_spintrylock.c
+++ b/test/trace_pthread_spintrylock.c
@@ -1,7 +1,9 @@
+#include <marker.h>
 #include <pthread.h>
 #include <trace_checker.h>
 
 struct expected_entry expected[] = {
+    EXPECT_SUFFIX(COLDTRACE_TEST_MARKER),
     EXPECT_SOME(COLDTRACE_ALLOC, 0, 1),
     EXPECT_SOME(COLDTRACE_FREE, 0, 1),
     EXPECT_VALUE(COLDTRACE_LOCK_ACQUIRE, 0),
@@ -14,6 +16,7 @@ int
 main()
 {
     register_expected_trace(1, expected);
+    coldtrace_test_marker();
 
     pthread_spinlock_t l;
     if (pthread_spin_init(&l, PTHREAD_PROCESS_PRIVATE) != 0) {

--- a/test/trace_read_write_range.c
+++ b/test/trace_read_write_range.c
@@ -1,9 +1,10 @@
 #include <coldtrace/log.h>
+#include <marker.h>
 #include <pthread.h>
 #include <trace_checker.h>
 
 struct expected_entry expected_1[] = {
-    EXPECT_ENTRY(COLDTRACE_ALLOC),
+    EXPECT_SUFFIX(COLDTRACE_TEST_MARKER),
     EXPECT_VALUE(COLDTRACE_THREAD_CREATE, 0),
     EXPECT_ENTRY(COLDTRACE_READ),
     EXPECT_VALUE(COLDTRACE_THREAD_JOIN, 0),
@@ -67,6 +68,7 @@ main()
     register_expected_trace(1, expected_1);
     register_expected_trace(2, expected_2);
     register_expected_trace(3, expected_3);
+    coldtrace_test_marker();
 
     pthread_t t1;
     pthread_t t2;

--- a/test/trace_read_write_size.c
+++ b/test/trace_read_write_size.c
@@ -1,8 +1,9 @@
 #include <coldtrace/log.h>
+#include <marker.h>
 #include <trace_checker.h>
 
 struct expected_entry expected_1[] = {
-    EXPECT_SOME(COLDTRACE_ALLOC, 0, 1),
+    EXPECT_SUFFIX(COLDTRACE_TEST_MARKER),
     EXPECT_VALUE_SIZE(COLDTRACE_ALLOC, 0, 10 * sizeof(int)),
     EXPECT_VALUE_SIZE(COLDTRACE_WRITE, 0, sizeof(int)),
     EXPECT_SOME_SIZE(COLDTRACE_WRITE, 9, 9, sizeof(int)),
@@ -19,6 +20,7 @@ int
 main(void)
 {
     register_expected_trace(1, expected_1);
+    coldtrace_test_marker();
 
     // alloc
     int *arr = (int *)malloc(MAX_ENTRIES * sizeof(int));

--- a/test/trace_write_var.c
+++ b/test/trace_write_var.c
@@ -1,11 +1,13 @@
 #include "trace_checker.h"
 
 #include <coldtrace/log.h>
+#include <marker.h>
 #include <pthread.h>
 #include <stdbool.h>
 #include <stddef.h>
 
 struct expected_entry expected[] = {
+    EXPECT_SUFFIX(COLDTRACE_TEST_MARKER),
     EXPECT_SOME(COLDTRACE_ALLOC, 0, 1),
     EXPECT_SOME(COLDTRACE_FREE, 0, 1),
     EXPECT_SUFFIX(COLDTRACE_WRITE),
@@ -21,6 +23,7 @@ int
 main()
 {
     register_expected_trace(1, expected);
+    coldtrace_test_marker();
 
     x = 120;               // NOLINT // WRITE
     log_printf("%d\n", x); // READ

--- a/test/trace_zero_flag.c
+++ b/test/trace_zero_flag.c
@@ -1,6 +1,8 @@
+#include <marker.h>
 #include <trace_checker.h>
 
 struct expected_entry trace[] = {
+    EXPECT_SUFFIX(COLDTRACE_TEST_MARKER),
     EXPECT_SOME(COLDTRACE_ALLOC, 0, 1),
     EXPECT_SOME(COLDTRACE_FREE, 0, 1),
     EXPECT_ENTRY(COLDTRACE_READ),
@@ -14,5 +16,6 @@ int
 main()
 {
     register_expected_trace(1, trace);
+    coldtrace_test_marker();
     return x;
 }


### PR DESCRIPTION
Introduce a new marker event to define explicit starting points in the trace stream. This includes:

- Define `EVENT_TEST_MARKER` and supporting structures.
- Implement an interposer to publish the event when `coldtrace_test_marker()` is called.
- Add a subscriber to capture the event and write it to the trace log.
- Add `coldtrace_test_marker()` to main thread entry of every test and prepend `COLDTRACE_TEST_MARKER` wildcard to expected traces.

This allows for more robust trace validation by decoupling test logic from early-execution framework noise.