### PR TITLE
Refactor and optimize trace dump script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ results
 .kakrc
 deps/bingo-installer/
 deps/libvsync-installer/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -24,7 +24,27 @@ See the log output (optional):
 
     scripts/trace_dump.py traces/freezer_log_1_0.bin
 
+`trace_dump.py` accepts a file named `freezer_log_<tid>_<fragment>.bin` and
+dumps every fragment for that thread in numeric fragment order. The selected
+fragment does not have to be the first one. Stack state is reconstructed across
+fragment boundaries.
+
+Use `-d` or `--debug` to print file, version-header, and decoder diagnostics to
+standard error while keeping the decoded events on standard output:
+
+    scripts/trace_dump.py --debug traces/freezer_log_1_0.bin
+
+The trace format contains an 8-byte version header followed by variable-sized
+entries using the current little-endian, 64-bit Coldtrace layouts. Trace files
+are preallocated, and an all-zero tail marks the end of their entries. Invalid
+filenames, truncated entries, unknown entry types, and inconsistent stack diffs
+are reported with a nonzero exit status and file offset.
+
+Fragment numbers are normally chronological. If `COLDTRACE_MAX_FILES` causes
+the writer to wrap and overwrite fragments, the retained files do not contain
+enough generation metadata to recover their original chronology or missing
+stack state.
+
 Run freezer analysis (optional):
 
     freezer -f traces
-

--- a/scripts/trace_dump.py
+++ b/scripts/trace_dump.py
@@ -1,55 +1,37 @@
 #!/usr/bin/env python3
-"""
-Python script to unpack L3 logging file into human-readable trace messages.
-L3: Lightweight Logging Library, Version 0.1
-Date 2023-12-24
-Copyright (c) 2023-2024
-"""
-import sys
-import struct
-import subprocess
-import os
+"""Display Coldtrace binary trace files in a human-readable form."""
+
+import argparse
+import mmap
 import re
-from collections import defaultdict
+import struct
+import sys
+from dataclasses import dataclass
+from enum import IntEnum
+from pathlib import Path
+from typing import Iterator, TextIO
 
-def get_multiple_file_log(s):
-    absolute_path = os.path.abspath(s)
-    print(absolute_path)
-    folder = os.path.dirname(absolute_path)
-    filename = os.path.basename(absolute_path)
-    print(folder)
-    print(filename)
-    pattern = r'freezer_log_(?P<tid>\d+)_(?P<nr>\d+)\.bin'
-    match = re.match(pattern, filename)
-    print(match)
-    if match and match["tid"] and match["nr"]:
-        tid = int(match["tid"])
-        files = [f for f in os.listdir(folder) if os.path.isfile(os.path.join(folder, f))]
-        files = [f for f in files if f.startswith(f"freezer_log_{tid}_")]
-        return (tid, [folder + '/' + f for f in sorted(files, key= lambda filename: int((filename.split("_")[-1]).split(".")[0]))])
-    else:
-        return list(s)
 
-# ##############################################################################
-# Constants that tie the unpacking logic to L3's core structure's layout
-# ##############################################################################
-COLD_VER_HEADER_SZ = 8     # bytes; sizeof(struct version_header)
-COLD_LOG_HEADER_SZ = 8  # bytes; offsetof(L3_LOG, slots)
-COLD_BASE_ENTRY_SZ = 8       # bytes; sizeof(L3_ENTRY)
-COLD_ACCESS_ENTRY_SZ = 4 * 8       # bytes; sizeof(L3_ENTRY)
-COLD_ALLOC_ENTRY_SZ = 5 * 8       # bytes; sizeof(L3_ENTRY)
-COLD_FREE_ENTRY_SZ = 4 * 8       # bytes; sizeof(L3_ENTRY)
-COLD_ATOMIC_ENTRY_SZ = 2 * 8       # bytes; sizeof(L3_ENTRY)
-COLD_ATOMIC_ACCESS_ENTRY_SZ = 3 * 8  # bytes; sizeof(L3_ENTRY)
-COLD_THREAD_ENTRY_SZ = 4 * 8       # bytes; sizeof(L3_ENTRY)
+TRACE_FILE_PATTERN = re.compile(
+    r"freezer_log_(?P<tid>\d+)_(?P<fragment>\d+)\.bin"
+)
 
-if len(sys.argv) != 2 and not (len(sys.argv) == 3 and sys.argv[2] == "-d"):
-    print(f"Usage: {sys.argv[0]} <logfile> [-d]")
-    sys.exit(0)
+VERSION_HEADER = struct.Struct("<IBBBB")
+ENTRY_HEADER = struct.Struct("<Q")
+FREE_FIELDS = struct.Struct("<QQII")
+ALLOC_FIELDS = struct.Struct("<QQQII")
+ACCESS_FIELDS = struct.Struct("<QQII")
+ATOMIC_ACCESS_FIELDS = struct.Struct("<QQ")
+ATOMIC_FIELDS = struct.Struct("<Q")
+THREAD_START_FIELDS = struct.Struct("<QQQ")
+ADDRESS = struct.Struct("<Q")
 
-from enum import Enum
+ZERO_FLAG = 0x80
+TYPE_MASK = 0xFF
+POINTER_MASK = 0x0000_FFFF_FFFF_FFFF
 
-class EntryType(Enum):
+
+class EntryType(IntEnum):
     FREE = 0
     ALLOC = 1
     READ = 2
@@ -66,184 +48,573 @@ class EntryType(Enum):
     RW_LOCK_ACQ_EXC = 13
     RW_LOCK_REL_SHR = 14
     RW_LOCK_REL_EXC = 15
-    RW_LOCK_REL     = 16
+    RW_LOCK_REL = 16
     CXA_GUARD_ACQUIRE = 17
     CXA_GUARD_RELEASE = 18
     THREAD_JOIN = 19
     THREAD_EXIT = 20
-    FENCE   = 21
-    MMAP    = 22
-    MUNMAP  = 23
+    FENCE = 21
+    MMAP = 22
+    MUNMAP = 23
     TEST_MARKER = 24
 
-ZERO_FLAG = 0b10000000
-PTR_MASK = 0x0000_FFFF_FFFF_FFFF
-BYTE_MASK = 0x0000_0000_0000_00FF
 
-debug = len(sys.argv) == 3 and sys.argv[2] == "-d"
-tid, file_list = get_multiple_file_log(sys.argv[1])
-# print(file_list)
-# Unpack the 1st n-bytes as an L3_LOG{} struct to get a hold
-# of the fbase-address stashed by the l3_init() call.
-# data = file.read(COLD_LOG_HEADER_SZ)
-# idx, = struct.unpack('<Q', data)
-# print(f"number of 8 byte chunks: {idx}")
-
-stacks = defaultdict(list)
-
-# pid_data = file.read(4088)
-# pylint: disable=invalid-name
-loc_prev = 0
-nentries = 0
-for f in file_list:
-    print(f"opening {f}")
-    with open(f, 'rb') as file:
-        header = file.read(COLD_VER_HEADER_SZ)
-        git_hash, padding, major, minor, patch = struct.unpack('<I B B B B', header) 
-        print(f"Coldtrace Version Header fields: git-commit-hash={git_hash:08x} version={major}.{minor}.{patch}")
-
-    # Keep reading chunks of log-entries from file ...
-        while True:
-            row = file.read(COLD_BASE_ENTRY_SZ)
-            len_row = len(row)
-            # Deal with eof
-            if not row or len_row == 0 or len_row < COLD_BASE_ENTRY_SZ:
-                break
-
-            ptr, = struct.unpack('<Q', row)
-            entry_type_raw = ptr & BYTE_MASK
-            ptr = (ptr >> 16) & PTR_MASK
-            
-            if debug:
-                print(f"entry_type_raw: {entry_type_raw} tid: {tid} ptr: {ptr:x}")
-            zero_flag = ZERO_FLAG & entry_type_raw > 0
-            entry_type = EntryType(entry_type_raw & ~ZERO_FLAG)
-            if (entry_type.value == 0): # free
-                raw_ext = file.read(COLD_FREE_ENTRY_SZ - COLD_BASE_ENTRY_SZ)
-                len_raw_ext = len(raw_ext)
-                if not raw_ext or raw_ext == 0 or len_raw_ext < (COLD_FREE_ENTRY_SZ - COLD_BASE_ENTRY_SZ) or (row == b'\x00'*COLD_BASE_ENTRY_SZ and raw_ext == b'\x00'*(COLD_FREE_ENTRY_SZ - COLD_BASE_ENTRY_SZ)):
-                    break
-                alloc_index, caller_0, popped_stack, stack_depth = struct.unpack('<QQII', raw_ext)
-                if debug:
-                    print(f"alloc_index: {alloc_index} caller_0: {caller_0:x} popped_stack: {popped_stack} stack_depth: {stack_depth}")
-                stacks[tid] = stacks[tid][:popped_stack]
-                if debug:
-                    print(stacks)
-                    print(f"reading {stack_depth - popped_stack} stack pointers")
-                for i in range(popped_stack, stack_depth):
-                    address, = struct.unpack('<Q', file.read(8))
-                    stacks[tid].append(address)
-                if debug:
-                    print(stacks)
-                caller_1 = stacks[tid][stack_depth - 1] if stack_depth - 1 >= 0 else 0
-                caller_2 = stacks[tid][stack_depth - 2] if stack_depth - 2 >= 0 else 0
-                if debug:
-                    print(stacks)
-            elif (entry_type.value == 1 or entry_type.value == 22 or entry_type.value == 23 ): # alloc
-                raw_ext = file.read(COLD_ALLOC_ENTRY_SZ - COLD_BASE_ENTRY_SZ)
-
-                size, alloc_index, caller_0, popped_stack, stack_depth = struct.unpack('<QQQII', raw_ext)
-                if debug:
-                    print(f"size: {size} caller_0: {caller_0:x} alloc_index: {alloc_index} popped_stack: {popped_stack} stack_depth: {stack_depth}")
-                stacks[tid] = stacks[tid][:popped_stack]
-                if debug:
-                    print(stacks)
-                    print(f"reading {stack_depth - popped_stack} stack pointers")
-                for i in range(popped_stack, stack_depth):
-                    address, = struct.unpack('<Q', file.read(8))
-                    stacks[tid].append(address)
-                if debug:
-                    print(stacks)
-                caller_1 = stacks[tid][stack_depth - 1] if stack_depth - 1 >= 0 else 0
-                caller_2 = stacks[tid][stack_depth - 2] if stack_depth - 2 >= 0 else 0
-                if debug:
-                    print(stacks)
-            elif (entry_type.value < 4):
-                raw_ext = file.read(COLD_ACCESS_ENTRY_SZ - COLD_BASE_ENTRY_SZ)
-
-                size, caller_0, popped_stack, stack_depth = struct.unpack('<QQII', raw_ext)
-                if debug:
-                    print(f"size: {size} caller_0: {caller_0:x} popped_stack: {popped_stack} stack_depth: {stack_depth}")
-                stacks[tid] = stacks[tid][:popped_stack]
-                if debug:
-                    print(stacks)
-                    print(f"reading {stack_depth - popped_stack} stack pointers")
-                for i in range(popped_stack, stack_depth):
-                    address, = struct.unpack('<Q', file.read(8))
-                    stacks[tid].append(address)
-                if debug:
-                    print(stacks)
-                caller_1 = stacks[tid][stack_depth - 1] if stack_depth - 1 >= 0 else 0
-                caller_2 = stacks[tid][stack_depth - 2] if stack_depth - 2 >= 0 else 0
-                if debug:
-                    print(stacks)
-            elif (entry_type.value == 9):
-                atomic_timestamp, thread_stack_ptr, thread_stack_size = struct.unpack('<QQQ', file.read(COLD_THREAD_ENTRY_SZ - COLD_BASE_ENTRY_SZ))
-            elif (entry_type.value == 4 or entry_type.value == 5): # ATOMIC_READ & ATOMIC_WRITE
-                raw_ext = file.read(COLD_ATOMIC_ACCESS_ENTRY_SZ - COLD_BASE_ENTRY_SZ)
-                size, atomic_timestamp = struct.unpack('<QQ', raw_ext)
-            elif (entry_type.value == 24):
-                # TEST_MARKER entry has no additional data
-                pass
-            else:
-                atomic_timestamp, = struct.unpack('<Q', file.read(COLD_ATOMIC_ENTRY_SZ - COLD_BASE_ENTRY_SZ))
-
-            match entry_type:
-                case EntryType.FREE:
-                    print(f"{nentries}) {tid}: Freed memory @{ptr:x} {stack_depth + 1}: {caller_0:x}, {caller_1:x}, {caller_2:x} [{alloc_index}]\n")
-                case EntryType.ALLOC:
-                    print(f"{nentries}) {tid}: Allocated {size}B of memory @{ptr:x} {stack_depth + 1}: {caller_0:x}, {caller_1:x}, {caller_2:x} [{alloc_index}]\n")
-                case EntryType.READ:
-                    if zero_flag:
-                        print(f"{nentries}) {tid}: ZeroRead access {size}B @{ptr:x} {stack_depth + 1}: {caller_0:x}, {caller_1:x}, {caller_2:x}\n")
-                    else:
-                        print(f"{nentries}) {tid}: Read access {size}B @{ptr:x} {stack_depth + 1}: {caller_0:x}, {caller_1:x}, {caller_2:x}\n")
-                case EntryType.WRITE:
-                    print(f"{nentries}) {tid}: write access {size}B @{ptr:x} {stack_depth + 1}: {caller_0:x}, {caller_1:x}, {caller_2:x}\n")
-                case EntryType.ATOMIC_READ:
-                    print(f"{nentries}) {tid}: atomic read {size}B @{ptr:x} [{atomic_timestamp}]\n")
-                case EntryType.ATOMIC_WRITE:
-                    print(f"{nentries}) {tid}: atomic write {size}B @{ptr:x} [{atomic_timestamp}]\n")
-                case EntryType.LOCK_ACQUIRE:
-                    print(f"{nentries}) {tid}: acquire lock @{ptr:x} [{atomic_timestamp}]\n")
-                case EntryType.LOCK_RELEASE:
-                    print(f"{nentries}) {tid}: release lock @{ptr:x} [{atomic_timestamp}]\n")
-                case EntryType.THREAD_CREATE:
-                    print(f"{nentries}) {tid}: thread create @{ptr:x} [{atomic_timestamp}]\n")
-                case EntryType.THREAD_START:
-                    print(f"{nentries}) {tid}: thread start @{ptr:x} {thread_stack_ptr:x} {thread_stack_size} [{atomic_timestamp}]\n")
-                case EntryType.THREAD_JOIN:
-                    print(f"{nentries}) {tid}: thread join @{ptr:x} [{atomic_timestamp}]\n")
-                case EntryType.THREAD_EXIT:
-                    print(f"{nentries}) {tid}: thread exit @{ptr:x} [{atomic_timestamp}]\n")
-                case EntryType.RW_LOCK_CREATE:
-                    print(f"{nentries}) {tid}: rw_lock create @{ptr:x} [{atomic_timestamp}]\n")
-                case EntryType.RW_LOCK_DESTROY:
-                    print(f"{nentries}) {tid}: rw_lock destroy @{ptr:x} [{atomic_timestamp}]\n")
-                case EntryType.RW_LOCK_ACQ_SHR:
-                    print(f"{nentries}) {tid}: rw_lock acq_shr @{ptr:x} [{atomic_timestamp}]\n")
-                case EntryType.RW_LOCK_ACQ_EXC:
-                    print(f"{nentries}) {tid}: rw_lock acq_exc @{ptr:x} [{atomic_timestamp}]\n")
-                case EntryType.RW_LOCK_REL_SHR:
-                    print(f"{nentries}) {tid}: rw_lock rel_shr @{ptr:x} [{atomic_timestamp}]\n")
-                case EntryType.RW_LOCK_REL_EXC:
-                    print(f"{nentries}) {tid}: rw_lock rel_exc @{ptr:x} [{atomic_timestamp}]\n")
-                case EntryType.RW_LOCK_REL:
-                    print(f"{nentries}) {tid}: rw_lock rel @{ptr:x} [{atomic_timestamp}]\n")
-                case EntryType.FENCE:
-                    print(f"{nentries}) {tid}: fence [{atomic_timestamp}]\n")
-                case EntryType.TEST_MARKER:
-                    print(f"{nentries}) {tid}: test marker\n")
-                case EntryType.CXA_GUARD_ACQUIRE:
-                    print(f"{nentries}) {tid}: acquire cxa_guard @{ptr:x} [{atomic_timestamp}]\n")
-                case EntryType.CXA_GUARD_RELEASE:
-                    print(f"{nentries}) {tid}: release cxa_guard @{ptr:x} [{atomic_timestamp}]\n")
-                case EntryType.MMAP:
-                    print(f"{nentries}) {tid}: mmap-ed region of {size} from {ptr:x} {stack_depth + 1}: {caller_0:x}, {caller_1:x}, {caller_2:x} [{alloc_index}]\n")
-                case EntryType.MUNMAP:
-                    print(f"{nentries}) {tid}: munmap-ed region of {size} from {ptr:x} {stack_depth + 1}: {caller_0:x}, {caller_1:x}, {caller_2:x} [{alloc_index}]\n")
+STACK_ALLOC_TYPES = {
+    EntryType.ALLOC,
+    EntryType.MMAP,
+    EntryType.MUNMAP,
+}
+STACK_ACCESS_TYPES = {EntryType.READ, EntryType.WRITE}
+ATOMIC_ACCESS_TYPES = {EntryType.ATOMIC_READ, EntryType.ATOMIC_WRITE}
+STACK_TYPES = {EntryType.FREE} | STACK_ALLOC_TYPES | STACK_ACCESS_TYPES
+ENTRY_TYPES = tuple(EntryType(value) for value in range(len(EntryType)))
 
 
-            nentries += 1
+class TraceDumpError(Exception):
+    """An input or trace-format error suitable for displaying to the user."""
 
-print(f"Unpacked {nentries=} log-entries.")
+
+@dataclass(slots=True)
+class TraceEntry:
+    tid: int
+    type: EntryType
+    pointer: int
+    zero_flag: bool = False
+    size: int | None = None
+    alloc_index: int | None = None
+    atomic_index: int | None = None
+    caller: int | None = None
+    stack_depth: int = 0
+    caller_1: int = 0
+    caller_2: int = 0
+    thread_stack_ptr: int | None = None
+    thread_stack_size: int | None = None
+
+
+def discover_trace_files(logfile: str | Path) -> tuple[int, list[Path]]:
+    """Return the thread ID and all of its trace fragments in numeric order."""
+    requested = Path(logfile).absolute()
+    match = TRACE_FILE_PATTERN.fullmatch(requested.name)
+    if match is None:
+        raise TraceDumpError(
+            f"invalid trace filename '{requested.name}'; expected "
+            "freezer_log_<tid>_<fragment>.bin"
+        )
+    if not requested.is_file():
+        raise TraceDumpError(f"trace file does not exist: {requested}")
+
+    tid = int(match.group("tid"))
+    fragments: list[tuple[int, Path]] = []
+    for candidate in requested.parent.iterdir():
+        candidate_match = TRACE_FILE_PATTERN.fullmatch(candidate.name)
+        if candidate_match is None or not candidate.is_file():
+            continue
+        if int(candidate_match.group("tid")) != tid:
+            continue
+        fragments.append((int(candidate_match.group("fragment")), candidate))
+
+    fragments.sort(key=lambda item: (item[0], item[1].name))
+    return tid, [path for _, path in fragments]
+
+
+class TraceReader:
+    """Decode a sequence of trace fragments belonging to one thread."""
+
+    def __init__(
+        self, tid: int, debug: bool = False, diagnostics: TextIO | None = None
+    ) -> None:
+        self.tid = tid
+        self.stack: list[int] = []
+        self.debug = debug
+        self.diagnostics = diagnostics if diagnostics is not None else sys.stderr
+
+    def entries(self, files: list[Path]) -> Iterator[TraceEntry]:
+        for path in files:
+            yield from self._read_file(path)
+
+    def _read_file(self, path: Path) -> Iterator[TraceEntry]:
+        if self.debug:
+            self._debug(f"opening {path}")
+        try:
+            with path.open("rb") as trace_file:
+                file_size = trace_file.seek(0, 2)
+                if file_size < VERSION_HEADER.size:
+                    raise self._format_error(
+                        path,
+                        0,
+                        f"truncated version header: expected {VERSION_HEADER.size} "
+                        f"bytes, found {file_size}",
+                    )
+
+                with mmap.mmap(
+                    trace_file.fileno(), length=0, access=mmap.ACCESS_READ
+                ) as buffer:
+                    git_hash, padding, major, minor, patch = (
+                        VERSION_HEADER.unpack_from(buffer)
+                    )
+                    # Headers are informational here so traces from another build
+                    # remain inspectable, matching the original dumper behavior.
+                    if self.debug:
+                        self._debug(
+                            "Coldtrace Version Header fields: "
+                            f"git-commit-hash={git_hash:08x} "
+                            f"padding={padding} version={major}.{minor}.{patch}"
+                        )
+
+                    offset = VERSION_HEADER.size
+                    while offset < file_size:
+                        entry_offset = offset
+                        header_end = offset + ENTRY_HEADER.size
+                        if header_end > file_size:
+                            if not any(buffer[offset:file_size]):
+                                if self.debug:
+                                    self._debug(
+                                        f"{path}:{offset}: reached short "
+                                        "zero-filled tail"
+                                    )
+                                break
+                            raise self._format_error(
+                                path,
+                                offset,
+                                "truncated entry header: expected "
+                                f"{ENTRY_HEADER.size} bytes, found "
+                                f"{file_size - offset}",
+                            )
+
+                        (typed_pointer,) = ENTRY_HEADER.unpack_from(buffer, offset)
+                        offset = header_end
+                        raw_type = typed_pointer & TYPE_MASK
+                        type_value = raw_type & ~ZERO_FLAG
+                        if type_value >= len(ENTRY_TYPES):
+                            raise self._format_error(
+                                path,
+                                entry_offset,
+                                f"unknown entry type {raw_type:#x}",
+                            )
+                        entry_type = ENTRY_TYPES[type_value]
+                        pointer = (typed_pointer >> 16) & POINTER_MASK
+                        zero_flag = bool(raw_type & ZERO_FLAG)
+
+                        if self.debug:
+                            self._debug(
+                                f"{path}:{entry_offset}: raw_type={raw_type} "
+                                f"type={entry_type.name} tid={self.tid} "
+                                f"ptr={pointer:x}"
+                            )
+
+                        # Memory accesses dominate real traces, so keep their
+                        # successful decode path free of generic helper calls.
+                        if entry_type in STACK_ACCESS_TYPES:
+                            fields_end = offset + ACCESS_FIELDS.size
+                            if fields_end > file_size:
+                                raise self._format_error(
+                                    path,
+                                    offset,
+                                    "truncated access entry fields: expected "
+                                    f"{ACCESS_FIELDS.size} bytes, found "
+                                    f"{file_size - offset}",
+                                )
+                            size, caller, popped, depth = ACCESS_FIELDS.unpack_from(
+                                buffer, offset
+                            )
+                            stack_depth, caller_1, caller_2, offset = (
+                                self._read_stack(
+                                    buffer,
+                                    file_size,
+                                    path,
+                                    entry_offset,
+                                    fields_end,
+                                    popped,
+                                    depth,
+                                )
+                            )
+                            entry = TraceEntry(
+                                self.tid,
+                                entry_type,
+                                pointer,
+                                zero_flag=zero_flag,
+                                size=size,
+                                caller=caller,
+                                stack_depth=stack_depth,
+                                caller_1=caller_1,
+                                caller_2=caller_2,
+                            )
+                        else:
+                            entry, offset = self._read_entry(
+                                buffer,
+                                file_size,
+                                path,
+                                entry_offset,
+                                offset,
+                                typed_pointer,
+                                entry_type,
+                                pointer,
+                                zero_flag,
+                            )
+                        if entry is None:
+                            if self.debug:
+                                self._debug(
+                                    f"{path}:{entry_offset}: reached "
+                                    "zero-filled tail"
+                                )
+                            break
+                        if self.debug:
+                            self._debug(
+                                f"{path}:{entry_offset}: decoded {entry}"
+                            )
+                        yield entry
+        except OSError as error:
+            raise TraceDumpError(f"cannot read trace file '{path}': {error}") from error
+
+    def _read_entry(
+        self,
+        buffer: mmap.mmap,
+        file_size: int,
+        path: Path,
+        entry_offset: int,
+        offset: int,
+        typed_pointer: int,
+        entry_type: EntryType,
+        pointer: int,
+        zero_flag: bool,
+    ) -> tuple[TraceEntry | None, int]:
+        if entry_type is EntryType.TEST_MARKER:
+            return TraceEntry(self.tid, entry_type, pointer), offset
+
+        if entry_type is EntryType.FREE:
+            fields_end = offset + FREE_FIELDS.size
+            available_end = min(fields_end, file_size)
+            if typed_pointer == 0 and not any(buffer[offset:available_end]):
+                return None, file_size
+            if fields_end > file_size:
+                raise self._format_error(
+                    path,
+                    offset,
+                    "truncated free entry fields: "
+                    f"expected {FREE_FIELDS.size} bytes, found {file_size - offset}",
+                )
+            alloc_index, caller, popped, depth = FREE_FIELDS.unpack_from(
+                buffer, offset
+            )
+            stack_depth, caller_1, caller_2, offset = self._read_stack(
+                buffer, file_size, path, entry_offset, fields_end, popped, depth
+            )
+            return TraceEntry(
+                self.tid,
+                entry_type,
+                pointer,
+                zero_flag=zero_flag,
+                alloc_index=alloc_index,
+                caller=caller,
+                stack_depth=stack_depth,
+                caller_1=caller_1,
+                caller_2=caller_2,
+            ), offset
+
+        if entry_type in STACK_ALLOC_TYPES:
+            fields, offset = self._unpack_from(
+                buffer,
+                file_size,
+                ALLOC_FIELDS,
+                path,
+                offset,
+                "allocation entry fields",
+            )
+            size, alloc_index, caller, popped, depth = fields
+            stack_depth, caller_1, caller_2, offset = self._read_stack(
+                buffer, file_size, path, entry_offset, offset, popped, depth
+            )
+            return TraceEntry(
+                self.tid,
+                entry_type,
+                pointer,
+                zero_flag=zero_flag,
+                size=size,
+                alloc_index=alloc_index,
+                caller=caller,
+                stack_depth=stack_depth,
+                caller_1=caller_1,
+                caller_2=caller_2,
+            ), offset
+
+        if entry_type is EntryType.THREAD_START:
+            fields, offset = self._unpack_from(
+                buffer,
+                file_size,
+                THREAD_START_FIELDS,
+                path,
+                offset,
+                "thread-start entry fields",
+            )
+            atomic_index, thread_stack_ptr, thread_stack_size = fields
+            return TraceEntry(
+                self.tid,
+                entry_type,
+                pointer,
+                zero_flag=zero_flag,
+                atomic_index=atomic_index,
+                thread_stack_ptr=thread_stack_ptr,
+                thread_stack_size=thread_stack_size,
+            ), offset
+
+        if entry_type in ATOMIC_ACCESS_TYPES:
+            fields, offset = self._unpack_from(
+                buffer,
+                file_size,
+                ATOMIC_ACCESS_FIELDS,
+                path,
+                offset,
+                "atomic-access entry fields",
+            )
+            size, atomic_index = fields
+            return TraceEntry(
+                self.tid,
+                entry_type,
+                pointer,
+                zero_flag=zero_flag,
+                size=size,
+                atomic_index=atomic_index,
+            ), offset
+
+        fields, offset = self._unpack_from(
+            buffer,
+            file_size,
+            ATOMIC_FIELDS,
+            path,
+            offset,
+            "atomic entry fields",
+        )
+        (atomic_index,) = fields
+        return TraceEntry(
+            self.tid,
+            entry_type,
+            pointer,
+            zero_flag=zero_flag,
+            atomic_index=atomic_index,
+        ), offset
+
+    def _read_stack(
+        self,
+        buffer: mmap.mmap,
+        file_size: int,
+        path: Path,
+        entry_offset: int,
+        offset: int,
+        popped: int,
+        depth: int,
+    ) -> tuple[int, int, int, int]:
+        if popped > depth:
+            raise self._format_error(
+                path,
+                entry_offset,
+                f"invalid stack diff: popped {popped} exceeds depth {depth}",
+            )
+        if popped > len(self.stack):
+            raise self._format_error(
+                path,
+                entry_offset,
+                f"invalid stack diff: cannot retain {popped} frames from "
+                f"a {len(self.stack)}-frame stack",
+            )
+
+        del self.stack[popped:]
+        added = depth - popped
+        stack_end = offset + added * ADDRESS.size
+        if stack_end > file_size:
+            available = max(0, file_size - offset)
+            raise self._format_error(
+                path,
+                offset,
+                f"truncated stack addresses: expected {added * ADDRESS.size} "
+                f"bytes, found {available}",
+            )
+        if self.debug:
+            self._debug(
+                f"{path}:{entry_offset}: retaining {popped} stack frames and "
+                f"reading {added}"
+            )
+        while offset < stack_end:
+            (address,) = ADDRESS.unpack_from(buffer, offset)
+            self.stack.append(address)
+            offset += ADDRESS.size
+        caller_1 = self.stack[-1] if self.stack else 0
+        caller_2 = self.stack[-2] if depth >= 2 else 0
+        return depth, caller_1, caller_2, offset
+
+    @staticmethod
+    def _unpack_from(
+        buffer: mmap.mmap,
+        file_size: int,
+        layout: struct.Struct,
+        path: Path,
+        offset: int,
+        description: str,
+    ) -> tuple[tuple[int, ...], int]:
+        end = offset + layout.size
+        if end > file_size:
+            raise TraceReader._format_error(
+                path,
+                offset,
+                f"truncated {description}: expected {layout.size} bytes, "
+                f"found {max(0, file_size - offset)}",
+            )
+        return layout.unpack_from(buffer, offset), end
+
+    @staticmethod
+    def _format_error(path: Path, offset: int, message: str) -> TraceDumpError:
+        return TraceDumpError(f"{path}:{offset}: {message}")
+
+    def _debug(self, message: str) -> None:
+        if self.debug:
+            print(message, file=self.diagnostics)
+
+
+def format_entry(ordinal: int, entry: TraceEntry) -> str:
+    """Format one decoded entry using the established trace-dump vocabulary."""
+    if entry.type is EntryType.READ:
+        operation = "ZeroRead" if entry.zero_flag else "Read"
+        return (
+            f"{ordinal}) {entry.tid}: {operation} access {entry.size}B "
+            f"@{entry.pointer:x} {entry.stack_depth + 1}: {entry.caller:x}, "
+            f"{entry.caller_1:x}, {entry.caller_2:x}"
+        )
+    if entry.type is EntryType.WRITE:
+        return (
+            f"{ordinal}) {entry.tid}: write access {entry.size}B "
+            f"@{entry.pointer:x} {entry.stack_depth + 1}: {entry.caller:x}, "
+            f"{entry.caller_1:x}, {entry.caller_2:x}"
+        )
+
+    prefix = f"{ordinal}) {entry.tid}:"
+    pointer = f"{entry.pointer:x}"
+
+    if entry.type in STACK_TYPES:
+        if entry.caller is None:
+            raise ValueError(f"missing caller for {entry.type.name}")
+        callers = (
+            f"{entry.stack_depth + 1}: {entry.caller:x}, "
+            f"{entry.caller_1:x}, {entry.caller_2:x}"
+        )
+
+    match entry.type:
+        case EntryType.FREE:
+            return (
+                f"{prefix} Freed memory @{pointer} {callers} "
+                f"[{entry.alloc_index}]"
+            )
+        case EntryType.ALLOC:
+            return (
+                f"{prefix} Allocated {entry.size}B of memory @{pointer} "
+                f"{callers} [{entry.alloc_index}]"
+            )
+        case EntryType.ATOMIC_READ:
+            return (
+                f"{prefix} atomic read {entry.size}B @{pointer} "
+                f"[{entry.atomic_index}]"
+            )
+        case EntryType.ATOMIC_WRITE:
+            return (
+                f"{prefix} atomic write {entry.size}B @{pointer} "
+                f"[{entry.atomic_index}]"
+            )
+        case EntryType.LOCK_ACQUIRE:
+            return f"{prefix} acquire lock @{pointer} [{entry.atomic_index}]"
+        case EntryType.LOCK_RELEASE:
+            return f"{prefix} release lock @{pointer} [{entry.atomic_index}]"
+        case EntryType.THREAD_CREATE:
+            return f"{prefix} thread create @{pointer} [{entry.atomic_index}]"
+        case EntryType.THREAD_START:
+            return (
+                f"{prefix} thread start @{pointer} "
+                f"{entry.thread_stack_ptr:x} {entry.thread_stack_size} "
+                f"[{entry.atomic_index}]"
+            )
+        case EntryType.THREAD_JOIN:
+            return f"{prefix} thread join @{pointer} [{entry.atomic_index}]"
+        case EntryType.THREAD_EXIT:
+            return f"{prefix} thread exit @{pointer} [{entry.atomic_index}]"
+        case EntryType.RW_LOCK_CREATE:
+            return f"{prefix} rw_lock create @{pointer} [{entry.atomic_index}]"
+        case EntryType.RW_LOCK_DESTROY:
+            return f"{prefix} rw_lock destroy @{pointer} [{entry.atomic_index}]"
+        case EntryType.RW_LOCK_ACQ_SHR:
+            return f"{prefix} rw_lock acq_shr @{pointer} [{entry.atomic_index}]"
+        case EntryType.RW_LOCK_ACQ_EXC:
+            return f"{prefix} rw_lock acq_exc @{pointer} [{entry.atomic_index}]"
+        case EntryType.RW_LOCK_REL_SHR:
+            return f"{prefix} rw_lock rel_shr @{pointer} [{entry.atomic_index}]"
+        case EntryType.RW_LOCK_REL_EXC:
+            return f"{prefix} rw_lock rel_exc @{pointer} [{entry.atomic_index}]"
+        case EntryType.RW_LOCK_REL:
+            return f"{prefix} rw_lock rel @{pointer} [{entry.atomic_index}]"
+        case EntryType.FENCE:
+            return f"{prefix} fence [{entry.atomic_index}]"
+        case EntryType.TEST_MARKER:
+            return f"{prefix} test marker"
+        case EntryType.CXA_GUARD_ACQUIRE:
+            return f"{prefix} acquire cxa_guard @{pointer} [{entry.atomic_index}]"
+        case EntryType.CXA_GUARD_RELEASE:
+            return f"{prefix} release cxa_guard @{pointer} [{entry.atomic_index}]"
+        case EntryType.MMAP:
+            return (
+                f"{prefix} mmap-ed region of {entry.size} from {pointer} "
+                f"{callers} [{entry.alloc_index}]"
+            )
+        case EntryType.MUNMAP:
+            return (
+                f"{prefix} munmap-ed region of {entry.size} from {pointer} "
+                f"{callers} [{entry.alloc_index}]"
+            )
+
+    raise ValueError(f"cannot format entry type {entry.type}")
+
+
+def dump_trace(
+    logfile: str | Path,
+    debug: bool = False,
+    output: TextIO | None = None,
+    diagnostics: TextIO | None = None,
+) -> int:
+    """Decode and display all fragments associated with a trace file."""
+    output = output if output is not None else sys.stdout
+    diagnostics = diagnostics if diagnostics is not None else sys.stderr
+
+    tid, files = discover_trace_files(logfile)
+    reader = TraceReader(tid, debug=debug, diagnostics=diagnostics)
+    write = output.write
+    format_line = format_entry
+    nentries = 0
+    for nentries, entry in enumerate(reader.entries(files), start=1):
+        write(f"{format_line(nentries - 1, entry)}\n")
+    write(f"Unpacked nentries={nentries} log-entries.\n")
+    return nentries
+
+
+def create_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Display all Coldtrace fragments for the thread identified by LOGFILE."
+        )
+    )
+    parser.add_argument("logfile", help="a freezer_log_<tid>_<fragment>.bin file")
+    parser.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        help="show file and decoder diagnostics on stderr",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = create_argument_parser().parse_args(argv)
+    try:
+        dump_trace(args.logfile, debug=args.debug)
+    except (OSError, TraceDumpError) as error:
+        print(f"trace_dump.py: error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,14 @@ include_directories(../src)
 include_directories(checkers)
 include_directories(../deps/dice/test/include)
 
+find_package(Python3 3.10 COMPONENTS Interpreter)
+if(Python3_Interpreter_FOUND)
+  add_test(NAME trace_dump-test
+           COMMAND ${Python3_EXECUTABLE} -m unittest test.test_trace_dump)
+  set_tests_properties(trace_dump-test PROPERTIES
+                       WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+endif()
+
 add_library(trace_checker SHARED checkers/trace_checker.c checkers/indexes_checker.c)
 target_link_libraries(trace_checker PUBLIC vsync dice.h ${COLDTRACE_OBJS})
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,1 @@
+"""Python tests for Coldtrace tooling."""

--- a/test/test_trace_dump.py
+++ b/test/test_trace_dump.py
@@ -1,0 +1,364 @@
+import io
+import struct
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts import trace_dump  # noqa: E402
+
+
+VERSION_STRUCT = struct.Struct("<IBBBB")
+ENTRY_STRUCT = struct.Struct("<Q")
+FREE_STRUCT = struct.Struct("<QQII")
+ALLOC_STRUCT = struct.Struct("<QQQII")
+ACCESS_STRUCT = struct.Struct("<QQII")
+ATOMIC_ACCESS_STRUCT = struct.Struct("<QQ")
+ATOMIC_STRUCT = struct.Struct("<Q")
+THREAD_START_STRUCT = struct.Struct("<QQQ")
+ADDRESS_STRUCT = struct.Struct("<Q")
+
+VERSION_HEADER = VERSION_STRUCT.pack(0x1234ABCD, 5, 0, 1, 0)
+ZERO_FLAG = 0x80
+
+EXPECTED_ENTRY_TYPES = [
+    trace_dump.EntryType.FREE,
+    trace_dump.EntryType.ALLOC,
+    trace_dump.EntryType.READ,
+    trace_dump.EntryType.WRITE,
+    trace_dump.EntryType.ATOMIC_READ,
+    trace_dump.EntryType.ATOMIC_WRITE,
+    trace_dump.EntryType.LOCK_ACQUIRE,
+    trace_dump.EntryType.LOCK_RELEASE,
+    trace_dump.EntryType.THREAD_CREATE,
+    trace_dump.EntryType.THREAD_START,
+    trace_dump.EntryType.RW_LOCK_CREATE,
+    trace_dump.EntryType.RW_LOCK_DESTROY,
+    trace_dump.EntryType.RW_LOCK_ACQ_SHR,
+    trace_dump.EntryType.RW_LOCK_ACQ_EXC,
+    trace_dump.EntryType.RW_LOCK_REL_SHR,
+    trace_dump.EntryType.RW_LOCK_REL_EXC,
+    trace_dump.EntryType.RW_LOCK_REL,
+    trace_dump.EntryType.CXA_GUARD_ACQUIRE,
+    trace_dump.EntryType.CXA_GUARD_RELEASE,
+    trace_dump.EntryType.THREAD_JOIN,
+    trace_dump.EntryType.THREAD_EXIT,
+    trace_dump.EntryType.FENCE,
+    trace_dump.EntryType.MMAP,
+    trace_dump.EntryType.MUNMAP,
+    trace_dump.EntryType.TEST_MARKER,
+]
+
+
+def entry_header(entry_type, pointer, zero_flag=False):
+    raw_type = int(entry_type) | (ZERO_FLAG if zero_flag else 0)
+    typed_pointer = (pointer << 16) | raw_type
+    return ENTRY_STRUCT.pack(typed_pointer)
+
+
+def stack_addresses(*addresses):
+    return b"".join(ADDRESS_STRUCT.pack(address) for address in addresses)
+
+
+def make_entry(entry_type):
+    value = int(entry_type)
+    header = entry_header(
+        entry_type,
+        0x1000 + value,
+        zero_flag=entry_type is trace_dump.EntryType.READ,
+    )
+    size = 8 + value
+    index = 100 + value
+    caller = 0x2000 + value
+
+    if entry_type is trace_dump.EntryType.FREE:
+        return (
+            header
+            + FREE_STRUCT.pack(index, caller, 0, 2)
+            + stack_addresses(0xAA, 0xBB)
+        )
+    if entry_type is trace_dump.EntryType.ALLOC:
+        return (
+            header
+            + ALLOC_STRUCT.pack(size, index, caller, 1, 2)
+            + stack_addresses(0xCC)
+        )
+    if entry_type is trace_dump.EntryType.READ:
+        return (
+            header
+            + ACCESS_STRUCT.pack(size, caller, 2, 3)
+            + stack_addresses(0xDD)
+        )
+    if entry_type is trace_dump.EntryType.WRITE:
+        return header + ACCESS_STRUCT.pack(size, caller, 1, 1)
+    if entry_type is trace_dump.EntryType.MMAP:
+        return header + ALLOC_STRUCT.pack(size, index, caller, 0, 0)
+    if entry_type is trace_dump.EntryType.MUNMAP:
+        return (
+            header
+            + ALLOC_STRUCT.pack(size, index, caller, 0, 2)
+            + stack_addresses(0xEE, 0xFF)
+        )
+    if entry_type is trace_dump.EntryType.THREAD_START:
+        return header + THREAD_START_STRUCT.pack(index, 0x3000, 0x4000)
+    if entry_type in {
+        trace_dump.EntryType.ATOMIC_READ,
+        trace_dump.EntryType.ATOMIC_WRITE,
+    }:
+        return header + ATOMIC_ACCESS_STRUCT.pack(size, index)
+    if entry_type is trace_dump.EntryType.TEST_MARKER:
+        return header
+    return header + ATOMIC_STRUCT.pack(index)
+
+
+class TraceDumpTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.trace_directory = Path(self.temporary_directory.name)
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def write_trace(self, name, contents):
+        path = self.trace_directory / name
+        path.write_bytes(contents)
+        return path
+
+    def make_complete_trace(self):
+        entry_types = EXPECTED_ENTRY_TYPES
+        first_fragment = self.write_trace(
+            "freezer_log_7_2.bin",
+            VERSION_HEADER + make_entry(entry_types[0]) + bytes(64),
+        )
+        requested_fragment = self.write_trace(
+            "freezer_log_7_10.bin",
+            VERSION_HEADER
+            + b"".join(make_entry(entry_type) for entry_type in entry_types[1:])
+            + bytes(64),
+        )
+        self.write_trace(
+            "freezer_log_8_0.bin",
+            VERSION_HEADER + make_entry(trace_dump.EntryType.THREAD_EXIT),
+        )
+        self.write_trace("freezer_log_7_bad.bin", b"not a trace")
+        return first_fragment, requested_fragment
+
+    def test_discovers_fragments_in_numeric_order(self):
+        first_fragment, requested_fragment = self.make_complete_trace()
+
+        tid, fragments = trace_dump.discover_trace_files(requested_fragment)
+
+        self.assertEqual(7, tid)
+        self.assertEqual([first_fragment, requested_fragment], fragments)
+
+    def test_decodes_and_formats_every_entry_type(self):
+        _, requested_fragment = self.make_complete_trace()
+        tid, fragments = trace_dump.discover_trace_files(requested_fragment)
+
+        entries = list(trace_dump.TraceReader(tid).entries(fragments))
+
+        self.assertEqual(
+            list(range(25)), [int(entry) for entry in EXPECTED_ENTRY_TYPES]
+        )
+        self.assertEqual(EXPECTED_ENTRY_TYPES, [entry.type for entry in entries])
+        self.assertTrue(entries[trace_dump.EntryType.READ].zero_flag)
+        self.assertEqual(3, entries[2].stack_depth)
+        self.assertEqual(0xDD, entries[2].caller_1)
+        self.assertEqual(0xCC, entries[2].caller_2)
+        self.assertEqual(0x3000, entries[9].thread_stack_ptr)
+        self.assertEqual(0x4000, entries[9].thread_stack_size)
+
+        output = io.StringIO()
+        count = trace_dump.dump_trace(requested_fragment, output=output)
+        lines = output.getvalue().splitlines()
+
+        self.assertEqual(25, count)
+        self.assertEqual(26, len(lines))
+        self.assertNotIn("", lines)
+        self.assertEqual(
+            "0) 7: Freed memory @1000 3: 2000, bb, aa [100]", lines[0]
+        )
+        self.assertEqual(
+            "1) 7: Allocated 9B of memory @1001 3: 2001, cc, aa [101]",
+            lines[1],
+        )
+        self.assertEqual(
+            "2) 7: ZeroRead access 10B @1002 4: 2002, dd, cc", lines[2]
+        )
+        self.assertEqual(
+            "3) 7: write access 11B @1003 2: 2003, aa, 0", lines[3]
+        )
+        self.assertEqual(
+            "9) 7: thread start @1009 3000 16384 [109]", lines[9]
+        )
+        self.assertEqual("21) 7: fence [121]", lines[21])
+        self.assertEqual(
+            "22) 7: mmap-ed region of 30 from 1016 1: 2016, 0, 0 [122]",
+            lines[22],
+        )
+        self.assertEqual(
+            "23) 7: munmap-ed region of 31 from 1017 3: 2017, ff, ee [123]",
+            lines[23],
+        )
+        self.assertEqual("24) 7: test marker", lines[24])
+        self.assertEqual("Unpacked nentries=25 log-entries.", lines[25])
+
+        normal_read = trace_dump.TraceEntry(
+            tid=7,
+            type=trace_dump.EntryType.READ,
+            pointer=0x123,
+            size=4,
+            caller=0x456,
+        )
+        self.assertEqual(
+            "0) 7: Read access 4B @123 1: 456, 0, 0",
+            trace_dump.format_entry(0, normal_read),
+        )
+
+    def test_accepts_short_zero_filled_tails(self):
+        for tail_size in (1, 7, 8, 16, 24, 32):
+            with self.subTest(tail_size):
+                path = self.write_trace(
+                    "freezer_log_1_0.bin",
+                    VERSION_HEADER
+                    + make_entry(trace_dump.EntryType.THREAD_EXIT)
+                    + bytes(tail_size),
+                )
+                entries = list(trace_dump.TraceReader(1).entries([path]))
+                self.assertEqual(
+                    [trace_dump.EntryType.THREAD_EXIT],
+                    [entry.type for entry in entries],
+                )
+
+    def test_disabled_debug_does_not_format_entry_representations(self):
+        path = self.write_trace(
+            "freezer_log_1_0.bin",
+            VERSION_HEADER + make_entry(trace_dump.EntryType.THREAD_EXIT),
+        )
+
+        with mock.patch.object(
+            trace_dump.TraceEntry,
+            "__repr__",
+            side_effect=AssertionError("entry representation was formatted"),
+        ):
+            entries = list(trace_dump.TraceReader(1).entries([path]))
+
+        self.assertEqual(1, len(entries))
+
+    def test_stack_updates_mutate_state_in_place(self):
+        depth = 64
+        first = (
+            entry_header(trace_dump.EntryType.READ, 1)
+            + ACCESS_STRUCT.pack(8, 2, 0, depth)
+            + stack_addresses(*range(depth))
+        )
+        unchanged = (
+            entry_header(trace_dump.EntryType.READ, 1)
+            + ACCESS_STRUCT.pack(8, 2, depth, depth)
+        )
+        path = self.write_trace(
+            "freezer_log_1_0.bin",
+            VERSION_HEADER + first + unchanged * 100 + bytes(32),
+        )
+        reader = trace_dump.TraceReader(1)
+        stack_identity = id(reader.stack)
+
+        count = sum(1 for _ in reader.entries([path]))
+
+        self.assertEqual(101, count)
+        self.assertEqual(stack_identity, id(reader.stack))
+        self.assertEqual(list(range(depth)), reader.stack)
+
+    def test_cli_keeps_normal_output_clean_and_sends_debug_to_stderr(self):
+        _, requested_fragment = self.make_complete_trace()
+        command = [
+            sys.executable,
+            str(PROJECT_ROOT / "scripts" / "trace_dump.py"),
+            str(requested_fragment),
+        ]
+
+        normal = subprocess.run(command, text=True, capture_output=True, check=False)
+        debug = subprocess.run(
+            [*command, "--debug"], text=True, capture_output=True, check=False
+        )
+
+        self.assertEqual(0, normal.returncode)
+        self.assertEqual("", normal.stderr)
+        self.assertNotIn("opening", normal.stdout)
+        self.assertNotIn("\n\n", normal.stdout)
+        self.assertEqual(normal.stdout, debug.stdout)
+        self.assertEqual(0, debug.returncode)
+        self.assertIn("opening", debug.stderr)
+        self.assertIn("Coldtrace Version Header fields", debug.stderr)
+        self.assertIn("type=FREE", debug.stderr)
+        self.assertIn("reached zero-filled tail", debug.stderr)
+
+    def test_reports_invalid_filename_and_missing_file(self):
+        invalid = self.write_trace("trace.bin", VERSION_HEADER)
+
+        with self.assertRaisesRegex(
+            trace_dump.TraceDumpError, "expected freezer_log_<tid>_<fragment>"
+        ):
+            trace_dump.discover_trace_files(invalid)
+        with self.assertRaisesRegex(trace_dump.TraceDumpError, "does not exist"):
+            trace_dump.discover_trace_files(
+                self.trace_directory / "freezer_log_1_0.bin"
+            )
+
+    def test_reports_truncated_and_invalid_entries_with_offsets(self):
+        cases = {
+            "version header": b"short",
+            "unknown entry type": VERSION_HEADER
+            + ENTRY_STRUCT.pack(25),
+            "truncated atomic entry fields": VERSION_HEADER
+            + entry_header(trace_dump.EntryType.FENCE, 1)
+            + b"\x01\x02",
+            "popped 2 exceeds depth 1": VERSION_HEADER
+            + entry_header(trace_dump.EntryType.FREE, 1)
+            + FREE_STRUCT.pack(1, 2, 2, 1),
+            "cannot retain 1 frames": VERSION_HEADER
+            + entry_header(trace_dump.EntryType.FREE, 1)
+            + FREE_STRUCT.pack(1, 2, 1, 1),
+            "truncated stack address": VERSION_HEADER
+            + entry_header(trace_dump.EntryType.FREE, 1)
+            + FREE_STRUCT.pack(1, 2, 0, 1)
+            + b"\x01",
+        }
+
+        for expected_message, contents in cases.items():
+            with self.subTest(expected_message):
+                path = self.write_trace("freezer_log_1_0.bin", contents)
+                with self.assertRaisesRegex(
+                    trace_dump.TraceDumpError, expected_message
+                ) as raised:
+                    list(trace_dump.TraceReader(1).entries([path]))
+                self.assertIn(str(path), str(raised.exception))
+
+    def test_cli_reports_trace_errors_without_a_traceback(self):
+        invalid = self.write_trace("trace.bin", VERSION_HEADER)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(PROJECT_ROOT / "scripts" / "trace_dump.py"),
+                str(invalid),
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(1, result.returncode)
+        self.assertEqual("", result.stdout)
+        self.assertIn("trace_dump.py: error:", result.stderr)
+        self.assertNotIn("Traceback", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- rewrite `trace_dump.py` into testable discovery, parsing, formatting, and CLI layers
- decode all current trace entry types, including `TEST_MARKER`, with bounds-checked stack reconstruction and clear errors
- use per-fragment mmap parsing and compact entry state to keep large trace dumps fast and memory-bounded
- document fragment handling and register generated binary-format tests with CTest

## Compatibility
- preserves event ordering, values, fragment discovery, stack reconstruction, and established event wording
- removes the noisy unconditional preamble and blank lines
- sends optional `-d`/`--debug` diagnostics to stderr

## Performance
On `bench/leveldb/traces/freezer_log_2_0.bin`, which selects 927 fragments (about 1.9 GiB):

- previous rewrite: 11m11s
- rebased implementation: 3m44s
- peak RSS: about 19 MiB

A 65,267-entry real fragment was also compared line-for-line with the old dumper.

## Verification
- `python3 -B -m unittest test.test_trace_dump`
- clean CMake build with the recorded submodule commit
- `ctest --test-dir build --output-on-failure` (47/47 passed)
- `git diff --check`